### PR TITLE
Add daemon feature flag to contract derive

### DIFF
--- a/cw-orch/Cargo.toml
+++ b/cw-orch/Cargo.toml
@@ -36,6 +36,7 @@ daemon = [
   "dep:bitcoin",
   "dep:prost",
   "dep:sha256",
+  "cw-orch-contract-derive/propagate_daemon"
 ]
 
 [dependencies]

--- a/packages/cw-orch-contract-derive/Cargo.toml
+++ b/packages/cw-orch-contract-derive/Cargo.toml
@@ -10,6 +10,9 @@ description = "Attribute macro for creating a contract interface."
 [lib]
 proc-macro = true
 
+[features]
+propagate_daemon = []
+
 [dependencies]
 convert_case = "0.6.0"
 log = "0.4.17"


### PR DESCRIPTION
This fix makes the implementation of `Uploadable<Daemon>` feature-flagged and enables it when `cw-orch` is built with the `daemon` feature.