### PR TITLE
Throw error on failed tx

### DIFF
--- a/cw-orch/src/daemon/channel.rs
+++ b/cw-orch/src/daemon/channel.rs
@@ -10,10 +10,7 @@ use crate::DaemonError;
 pub struct DaemonChannel {}
 
 impl DaemonChannel {
-    pub async fn connect(
-        grpc: &[Grpc],
-        chain_id: &ChainId,
-    ) -> Result<Channel, DaemonError> {
+    pub async fn connect(grpc: &[Grpc], chain_id: &ChainId) -> Result<Channel, DaemonError> {
         let mut successful_connections = vec![];
 
         for Grpc { address, .. } in grpc.iter() {

--- a/cw-orch/src/daemon/channel.rs
+++ b/cw-orch/src/daemon/channel.rs
@@ -13,7 +13,7 @@ impl DaemonChannel {
     pub async fn connect(
         grpc: &[Grpc],
         chain_id: &ChainId,
-    ) -> Result<Option<Channel>, DaemonError> {
+    ) -> Result<Channel, DaemonError> {
         let mut successful_connections = vec![];
 
         for Grpc { address, .. } in grpc.iter() {
@@ -88,7 +88,7 @@ impl DaemonChannel {
             return Err(DaemonError::CannotConnectGRPC);
         }
 
-        Ok(Some(successful_connections[0].clone()))
+        Ok(successful_connections.pop().unwrap())
     }
 }
 

--- a/cw-orch/src/daemon/error.rs
+++ b/cw-orch/src/daemon/error.rs
@@ -90,6 +90,8 @@ pub enum DaemonError {
     NewNetwork(String),
     #[error("Can not connect to any grpc endpoint that was provided.")]
     CannotConnectGRPC,
+    #[error("tx failed: {reason} with code {code}")]
+    TxFailed { code: usize, reason: String },
     #[error("The list of grpc endpoints is empty")]
     GRPCListIsEmpty,
     #[error("no wasm path provided for contract.")]

--- a/cw-orch/src/daemon/queriers/node.rs
+++ b/cw-orch/src/daemon/queriers/node.rs
@@ -5,13 +5,16 @@ use crate::{
     DaemonError,
 };
 
-use cosmrs::tendermint::{Block, Time};
+use cosmrs::{
+    proto::cosmos::tx::v1beta1::SimulateResponse,
+    tendermint::{Block, Time},
+};
 use tokio::time::sleep;
 use tonic::transport::Channel;
 
 use super::DaemonQuerier;
 
-const MAX_TX_QUERY_RETRIES: u64 = 5;
+const MAX_TX_QUERY_RETRIES: usize = 5;
 
 /// Querier for the Tendermint node.
 /// Supports queries for block and tx information
@@ -61,7 +64,7 @@ impl Node {
         let mut client =
             cosmos_modules::tx::service_client::ServiceClient::new(self.channel.clone());
         #[allow(deprecated)]
-        let resp = client
+        let resp: SimulateResponse = client
             .simulate(cosmos_modules::tx::SimulateRequest { tx: None, tx_bytes })
             .await?
             .into_inner();
@@ -86,7 +89,7 @@ impl Node {
         let mut client =
             cosmos_modules::tx::service_client::ServiceClient::new(self.channel.clone());
 
-        let request = cosmos_modules::tx::GetTxRequest { hash };
+        let request = cosmos_modules::tx::GetTxRequest { hash: hash.clone() };
 
         for _ in 0..MAX_TX_QUERY_RETRIES {
             match client.get_tx(request.clone()).await {
@@ -102,10 +105,7 @@ impl Node {
                 }
             }
         }
-
-        panic!(
-            "couldn't find transaction after {} attempts!",
-            MAX_TX_QUERY_RETRIES
-        );
+        // return error if tx not found by now
+        Err(DaemonError::TXNotFound(hash, MAX_TX_QUERY_RETRIES))
     }
 }

--- a/cw-orch/src/daemon/state.rs
+++ b/cw-orch/src/daemon/state.rs
@@ -43,9 +43,8 @@ impl DaemonState {
         log::info!("Found {} gRPC endpoints", chain_info.apis.grpc.len());
 
         // find working grpc channel
-        let grpc_channel = DaemonChannel::connect(&chain_info.apis.grpc, &chain_info.chain_id)
-            .await?
-            .unwrap();
+        let grpc_channel =
+            DaemonChannel::connect(&chain_info.apis.grpc, &chain_info.chain_id).await?;
 
         // check if STATE_FILE en var is configured, fail if not
         let mut json_file_path = env::var("STATE_FILE").expect("STATE_FILE is not set");

--- a/cw-orch/tests/common/channel.rs
+++ b/cw-orch/tests/common/channel.rs
@@ -2,10 +2,10 @@ use cw_orch::{networks, DaemonChannel};
 
 use ibc_chain_registry::chain::Grpc;
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
-use speculoos::{asserting, prelude::OptionAssertions};
+use speculoos::{asserting, prelude::OptionAssertions, result::ResultAssertions};
 
 #[allow(unused)]
-pub async fn build_channel() -> Option<tonic::transport::Channel> {
+pub async fn build_channel() -> tonic::transport::Channel {
     let network = networks::LOCAL_JUNO;
 
     let grpcs: Vec<Grpc> = vec![Grpc {
@@ -15,11 +15,11 @@ pub async fn build_channel() -> Option<tonic::transport::Channel> {
 
     let chain: ChainId = ChainId::new(network.chain_id.to_owned(), 1);
 
-    let channel = DaemonChannel::connect(&grpcs, &chain).await.unwrap();
+    let channel = DaemonChannel::connect(&grpcs, &chain).await;
 
     asserting!("channel connection is succesful")
         .that(&channel)
-        .is_some();
+        .is_ok();
 
-    channel
+    channel.unwrap()
 }

--- a/cw-orch/tests/common/contract.rs
+++ b/cw-orch/tests/common/contract.rs
@@ -9,7 +9,8 @@ struct DeployId(());
 type Id = IdT<DeployId>;
 
 use cw_orch::{
-    contract, networks::LOCAL_JUNO, Contract, ContractWrapper, Daemon, Mock, Uploadable, WasmPath,
+    contract, networks::LOCAL_JUNO, Contract, ContractWrapper, CwEnv, Daemon, Mock, Uploadable,
+    WasmPath,
 };
 
 // path to local cw20.wasm artifact
@@ -22,6 +23,15 @@ const CW20_CONTRACT_WASM: &str = "tests/common/artifacts/cw20_base.wasm";
     cw20_base::msg::MigrateMsg
 )]
 pub struct Cw20;
+
+impl<Chain: CwEnv> Cw20<Chain> {
+    pub fn new(chain: Chain) -> Self {
+        let id = Id::new();
+        Self {
+            0: Contract::new(format!("cw-plus:cw20_base:{}", id), chain),
+        }
+    }
+}
 
 impl Uploadable<Mock> for Cw20<Mock> {
     fn source(&self) -> <Mock as cw_orch::TxHandler>::ContractSource {

--- a/cw-orch/tests/common/daemon.rs
+++ b/cw-orch/tests/common/daemon.rs
@@ -1,0 +1,27 @@
+use tokio::runtime::Runtime;
+
+use uid::Id as IdT;
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct DeployId(());
+
+type Id = IdT<DeployId>;
+
+use cw_orch::{
+    contract, networks::LOCAL_JUNO, Contract, ContractWrapper, Daemon, Mock, Uploadable, WasmPath,
+};
+
+/// Get the test-daemon object (local juno)
+pub fn daemon(runtime: &Runtime) -> (cosmwasm_std::Addr, Daemon) {
+    let id = Id::new();
+    let daemon = Daemon::builder()
+        .chain(LOCAL_JUNO)
+        .handle(runtime.handle())
+        .deployment_id(id.to_string())
+        .build()
+        .unwrap();
+
+    let sender = daemon.sender.address().unwrap();
+
+    (sender, daemon)
+}

--- a/cw-orch/tests/common/mod.rs
+++ b/cw-orch/tests/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod channel;
 pub mod contract;
+pub mod daemon;
 
 use std::{env, fs, path::Path, thread::sleep, time::Duration};
 

--- a/cw-orch/tests/querier.rs
+++ b/cw-orch/tests/querier.rs
@@ -20,7 +20,7 @@ use cosmrs::{
 #[test]
 fn general() {
     let rt = Arc::new(Runtime::new().unwrap());
-    let channel = rt.block_on(build_channel()).unwrap();
+    let channel = rt.block_on(build_channel());
 
     let node = Node::new(channel.clone());
     let block_height = rt.block_on(node.block_height());
@@ -37,7 +37,7 @@ fn general() {
 fn simulate_tx() {
     let rt = Arc::new(Runtime::new().unwrap());
 
-    let channel = rt.block_on(build_channel()).unwrap();
+    let channel = rt.block_on(build_channel());
 
     let node = Node::new(channel.clone());
 
@@ -79,7 +79,7 @@ fn simulate_tx() {
 #[test]
 fn contract_info() {
     let rt = Arc::new(Runtime::new().unwrap());
-    let channel = rt.block_on(build_channel()).unwrap();
+    let channel = rt.block_on(build_channel());
     let cosm_wasm = CosmWasm::new(channel.clone());
 
     let (sender, contract) = common::contract::start(&rt);

--- a/cw-orch/tests/sender.rs
+++ b/cw-orch/tests/sender.rs
@@ -1,0 +1,65 @@
+mod common;
+
+use cosmwasm_std::{coin, Uint128};
+use cw_orch::{networks::LOCAL_JUNO, *};
+use speculoos::{
+    result::{ContainingResultAssertions, ResultAssertions},
+    *,
+};
+use tokio::runtime::Runtime;
+
+#[test]
+fn tx_not_found_after_x() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut bad_config = LOCAL_JUNO;
+    bad_config.gas_denom = "baddenom";
+
+    let daemon = Daemon::builder()
+        .chain(bad_config)
+        .handle(rt.handle())
+        .build()
+        .unwrap();
+    let cw20 = common::contract::Cw20::new(daemon);
+
+    // attempt to execute with a wrong fee denom, hash won't be included in the block
+    let res = cw20.upload();
+
+    // we expect an error
+    asserting!("the transaction is not found")
+        .that(&res)
+        .is_err()
+        .matches(|e| e.to_string().contains("not found after"));
+}
+
+#[test]
+fn cosmwasm_exec_fails() {
+    let runtime = Runtime::new().unwrap();
+    let (sender, contract) = common::contract::start(&runtime);
+
+    // upload contract
+    let upload_res = contract.upload();
+    asserting!("upload is succesful").that(&upload_res).is_ok();
+
+    // init msg for contract
+    let init_msg = common::contract::get_init_msg(&sender);
+    contract
+        .instantiate(&init_msg, Some(&sender.clone()), None)
+        .unwrap();
+
+    // burn more than we have amount
+    let res = contract.execute(
+        &cw20_base::msg::ExecuteMsg::Burn {
+            amount: Uint128::from(1000000000000000000u128),
+        },
+        None,
+    );
+
+    // we expect an error
+    asserting!("contract execution failed")
+        .that(&res)
+        .is_err()
+        .matches(|e| match e {
+            CwOrcError::DaemonError(DaemonError::Status(_)) => true,
+            _ => false,
+        });
+}


### PR DESCRIPTION
Add an error if a transaction returns a result with a response_code != 1 as that signals that the tx did not successfully get included in the block. 

Also cleans up the channel creation function by removing the unused Option type on the constructor's result. 