### PR TITLE
Refactor `DaemonState` to include chain registry `ChainData`.

### DIFF
--- a/cw-orch/src/daemon/chain_info.rs
+++ b/cw-orch/src/daemon/chain_info.rs
@@ -1,0 +1,159 @@
+use std::env;
+
+use serde::{Deserialize, Serialize};
+
+use crate::prelude::CwOrchError;
+use ibc_chain_registry::chain::{Apis, ChainData as RegistryChainInfo, FeeToken, FeeTokens, Grpc};
+
+#[allow(clippy::from_over_into)]
+impl Into<RegistryChainInfo> for ChainInfo<'_> {
+    fn into(self) -> RegistryChainInfo {
+        RegistryChainInfo {
+            chain_name: self.network_info.id.to_string(),
+            chain_id: self.chain_id.to_string().into(),
+            bech32_prefix: self.network_info.pub_address_prefix.into(),
+            fees: FeeTokens {
+                fee_tokens: vec![FeeToken {
+                    fixed_min_gas_price: self.gas_price,
+                    denom: self.gas_denom.to_string(),
+                    ..Default::default()
+                }],
+            },
+            network_type: self.kind.to_string(),
+            apis: Apis {
+                grpc: self
+                    .grpc_urls
+                    .iter()
+                    .map(|url| Grpc {
+                        address: url.to_string(),
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            },
+            slip44: self.network_info.coin_type,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChainInfo<'a> {
+    /// Identifier for the network ex. columbus-2
+    pub chain_id: &'a str,
+    /// Max gas and denom info
+    // #[serde(with = "cosm_denom_format")]
+    pub gas_denom: &'a str,
+    /// gas price
+    pub gas_price: f64,
+    pub grpc_urls: &'a [&'a str],
+    /// Optional urls for custom functionality
+    pub lcd_url: Option<&'a str>,
+    pub fcd_url: Option<&'a str>,
+    /// Underlying network details (coin type, address prefix, etc)
+    pub network_info: NetworkInfo<'a>,
+    pub kind: ChainKind,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChainInfoOwned {
+    /// Identifier for the network ex. columbus-2
+    pub chain_id: String,
+    /// Max gas and denom info
+    // #[serde(with = "cosm_denom_format")]
+    pub gas_denom: String,
+    /// gas price
+    pub gas_price: f64,
+    pub grpc_urls: Vec<String>,
+    /// Optional urls for custom functionality
+    pub lcd_url: Option<String>,
+    pub fcd_url: Option<String>,
+    /// Underlying network details (coin type, address prefix, etc)
+    pub network_info: NetworkInfoOwned,
+    pub kind: ChainKind,
+}
+
+#[derive(Clone, Debug, Serialize, Default)]
+pub struct NetworkInfo<'a> {
+    pub id: &'a str,
+    /// address prefix
+    pub pub_address_prefix: &'a str,
+    /// coin type for key derivation
+    pub coin_type: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Default)]
+pub struct NetworkInfoOwned {
+    pub id: String,
+    /// address prefix
+    pub pub_address_prefix: String,
+    /// coin type for key derivation
+    pub coin_type: u32,
+}
+
+impl From<NetworkInfo<'_>> for NetworkInfoOwned {
+    fn from(info: NetworkInfo<'_>) -> Self {
+        Self {
+            id: info.id.to_owned(),
+            pub_address_prefix: info.pub_address_prefix.to_owned(),
+            coin_type: info.coin_type,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ChainKind {
+    Local,
+    Mainnet,
+    Testnet,
+}
+
+impl ChainKind {
+    pub fn new() -> Result<Self, CwOrchError> {
+        let network_id = env::var("NETWORK").expect("NETWORK is not set");
+        let network = match network_id.as_str() {
+            "testnet" => ChainKind::Testnet,
+            "mainnet" => ChainKind::Mainnet,
+            _ => ChainKind::Local,
+        };
+        Ok(network)
+    }
+
+    pub fn mnemonic_name(&self) -> &str {
+        match *self {
+            ChainKind::Local => "LOCAL_MNEMONIC",
+            ChainKind::Testnet => "TEST_MNEMONIC",
+            ChainKind::Mainnet => "MAIN_MNEMONIC",
+        }
+    }
+
+    pub fn multisig_name(&self) -> &str {
+        match *self {
+            ChainKind::Local => "LOCAL_MULTISIG",
+            ChainKind::Testnet => "TEST_MULTISIG",
+            ChainKind::Mainnet => "MAIN_MULTISIG",
+        }
+    }
+}
+
+impl ToString for ChainKind {
+    fn to_string(&self) -> String {
+        match *self {
+            ChainKind::Local => "local",
+            ChainKind::Testnet => "testnet",
+            ChainKind::Mainnet => "mainnet",
+        }
+        .into()
+    }
+}
+
+impl From<String> for ChainKind {
+    fn from(str: String) -> Self {
+        match str.as_str() {
+            "local" => ChainKind::Local,
+            "testnet" => ChainKind::Testnet,
+            "mainnet" => ChainKind::Mainnet,
+            _ => ChainKind::Local,
+        }
+    }
+}

--- a/cw-orch/src/daemon/chain_info.rs
+++ b/cw-orch/src/daemon/chain_info.rs
@@ -55,24 +55,6 @@ pub struct ChainInfo<'a> {
     pub kind: ChainKind,
 }
 
-#[derive(Clone, Debug)]
-pub struct ChainInfoOwned {
-    /// Identifier for the network ex. columbus-2
-    pub chain_id: String,
-    /// Max gas and denom info
-    // #[serde(with = "cosm_denom_format")]
-    pub gas_denom: String,
-    /// gas price
-    pub gas_price: f64,
-    pub grpc_urls: Vec<String>,
-    /// Optional urls for custom functionality
-    pub lcd_url: Option<String>,
-    pub fcd_url: Option<String>,
-    /// Underlying network details (coin type, address prefix, etc)
-    pub network_info: NetworkInfoOwned,
-    pub kind: ChainKind,
-}
-
 #[derive(Clone, Debug, Serialize, Default)]
 pub struct NetworkInfo<'a> {
     pub id: &'a str,
@@ -80,25 +62,6 @@ pub struct NetworkInfo<'a> {
     pub pub_address_prefix: &'a str,
     /// coin type for key derivation
     pub coin_type: u32,
-}
-
-#[derive(Clone, Debug, Serialize, Default)]
-pub struct NetworkInfoOwned {
-    pub id: String,
-    /// address prefix
-    pub pub_address_prefix: String,
-    /// coin type for key derivation
-    pub coin_type: u32,
-}
-
-impl From<NetworkInfo<'_>> for NetworkInfoOwned {
-    fn from(info: NetworkInfo<'_>) -> Self {
-        Self {
-            id: info.id.to_owned(),
-            pub_address_prefix: info.pub_address_prefix.to_owned(),
-            coin_type: info.coin_type,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/cw-orch/src/daemon/mod.rs
+++ b/cw-orch/src/daemon/mod.rs
@@ -1,4 +1,5 @@
 pub mod builder;
+pub mod chain_info;
 pub mod channel;
 pub mod core;
 pub mod error;

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -1,4 +1,4 @@
-use crate::daemon::state::{ChainInfo, ChainKind, NetworkInfo};
+use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
 pub const JUNO_NETWORK: NetworkInfo = NetworkInfo {
     id: "juno",

--- a/cw-orch/src/daemon/networks/mod.rs
+++ b/cw-orch/src/daemon/networks/mod.rs
@@ -9,7 +9,7 @@ pub mod neutron;
 pub mod osmosis;
 pub mod terra;
 
-pub use crate::daemon::state::{ChainInfo, ChainKind, NetworkInfo};
+pub use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 pub use archway::CONSTANTINE_1;
 pub use injective::{INJECTIVE_1, INJECTIVE_888};
 pub use juno::{JUNO_1, LOCAL_JUNO, UNI_6};

--- a/cw-orch/src/daemon/networks/osmosis.rs
+++ b/cw-orch/src/daemon/networks/osmosis.rs
@@ -1,4 +1,4 @@
-use crate::daemon::state::{ChainInfo, ChainKind, NetworkInfo};
+use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
 pub const OSMO_NETWORK: NetworkInfo = NetworkInfo {
     id: "osmosis",

--- a/cw-orch/src/daemon/networks/terra.rs
+++ b/cw-orch/src/daemon/networks/terra.rs
@@ -1,4 +1,4 @@
-use crate::daemon::state::{ChainInfo, ChainKind, NetworkInfo};
+use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
 pub const TERRA_NETWORK: NetworkInfo = NetworkInfo {
     id: "terra",

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -1,3 +1,4 @@
+use super::chain_info::ChainKind;
 use super::cosmos_modules::{self, auth::BaseAccount};
 use super::queriers::DaemonQuerier;
 use super::queriers::Node;
@@ -33,11 +34,12 @@ pub struct Sender<C: Signing + Context> {
 
 impl Sender<All> {
     pub fn new(daemon_state: &Rc<DaemonState>) -> Result<Sender<All>, DaemonError> {
+        let kind = ChainKind::from(daemon_state.chain_data.network_type.clone());
         // NETWORK_MNEMONIC_GROUP
-        let mnemonic = env::var(daemon_state.kind.mnemonic_name()).unwrap_or_else(|_| {
+        let mnemonic = env::var(kind.mnemonic_name()).unwrap_or_else(|_| {
             panic!(
                 "Wallet mnemonic environment variable {} not set.",
-                daemon_state.kind.mnemonic_name()
+                kind.mnemonic_name()
             )
         });
 
@@ -51,7 +53,7 @@ impl Sender<All> {
     ) -> Result<Sender<All>, DaemonError> {
         let secp = Secp256k1::new();
         let p_key: PrivateKey =
-            PrivateKey::from_words(&secp, mnemonic, 0, 0, daemon_state.network.coin_type)?;
+            PrivateKey::from_words(&secp, mnemonic, 0, 0, daemon_state.chain_data.slip44)?;
 
         let cosmos_private_key = SigningKey::from_slice(&p_key.raw_key()).unwrap();
         let sender = Sender {
@@ -61,7 +63,7 @@ impl Sender<All> {
         };
         log::info!(
             "Interacting with {} using address: {}",
-            daemon_state.chain_id,
+            daemon_state.chain_data.chain_id,
             sender.pub_addr_str()?
         );
         Ok(sender)
@@ -75,14 +77,14 @@ impl Sender<All> {
         Ok(self
             .private_key
             .public_key()
-            .account_id(&self.daemon_state.network.pub_address_prefix)?)
+            .account_id(&self.daemon_state.chain_data.bech32_prefix)?)
     }
 
     pub fn address(&self) -> Result<Addr, DaemonError> {
         Ok(Addr::unchecked(
             self.private_key
                 .public_key()
-                .account_id(&self.daemon_state.network.pub_address_prefix)?
+                .account_id(&self.daemon_state.chain_data.bech32_prefix)?
                 .to_string(),
         ))
     }
@@ -91,7 +93,7 @@ impl Sender<All> {
         Ok(self
             .private_key
             .public_key()
-            .account_id(&self.daemon_state.network.pub_address_prefix)?
+            .account_id(&self.daemon_state.chain_data.bech32_prefix)?
             .to_string())
     }
 
@@ -125,14 +127,13 @@ impl Sender<All> {
     }
 
     pub(crate) fn build_fee(&self, amount: impl Into<u128>, gas_limit: Option<u64>) -> Fee {
-        let amount = Coin {
-            amount: amount.into(),
-            denom: self.daemon_state.gas_denom.to_owned(),
-        };
-
+        let fee = Coin::new(
+            amount.into(),
+            &self.daemon_state.chain_data.fees.fee_tokens[0].denom,
+        )
+        .unwrap();
         let gas = gas_limit.unwrap_or(GAS_LIMIT);
-
-        Fee::from_amount_and_gas(amount, gas)
+        Fee::from_amount_and_gas(fee, gas)
     }
 
     pub async fn calculate_gas(
@@ -149,7 +150,7 @@ impl Sender<All> {
         let sign_doc = SignDoc::new(
             tx_body,
             &auth_info,
-            &Id::try_from(self.daemon_state.chain_id.clone())?,
+            &Id::try_from(self.daemon_state.chain_data.chain_id.to_string())?,
             account_number,
         )?;
 
@@ -182,7 +183,8 @@ impl Sender<All> {
         log::debug!("Simulated gas needed {:?}", sim_gas_used);
 
         let gas_expected = sim_gas_used as f64 * GAS_BUFFER;
-        let amount_to_pay = gas_expected * (self.daemon_state.gas_price + 0.00001);
+        let amount_to_pay = gas_expected
+            * (self.daemon_state.chain_data.fees.fee_tokens[0].fixed_min_gas_price + 0.00001);
 
         log::debug!("Calculated gas needed: {:?}", amount_to_pay);
 
@@ -194,7 +196,7 @@ impl Sender<All> {
         let sign_doc = SignDoc::new(
             &tx_body,
             &auth_info,
-            &Id::try_from(self.daemon_state.chain_id.clone())?,
+            &Id::try_from(self.daemon_state.chain_data.chain_id.to_string())?,
             account_number,
         )?;
 

--- a/cw-orch/src/daemon/state.rs
+++ b/cw-orch/src/daemon/state.rs
@@ -1,11 +1,15 @@
 use super::error::DaemonError;
-use crate::{daemon::channel::GrpcChannel, error::CwOrchError, state::StateInterface};
-use cosmrs::Denom;
+use crate::{
+    daemon::{chain_info::ChainKind, channel::GrpcChannel},
+    error::CwOrchError,
+    state::StateInterface,
+};
+
 use cosmwasm_std::Addr;
-use ibc_chain_registry::chain::{Apis, ChainData as RegistryChainInfo, FeeToken, FeeTokens, Grpc};
-use serde::{Deserialize, Serialize};
+use ibc_chain_registry::chain::ChainData;
+use serde::Serialize;
 use serde_json::{json, Value};
-use std::{collections::HashMap, env, fs::File, path::Path, rc::Rc, str::FromStr};
+use std::{collections::HashMap, env, fs::File, path::Path, rc::Rc};
 use tonic::transport::Channel;
 
 /// Stores the chain information and deployment state.
@@ -14,45 +18,34 @@ use tonic::transport::Channel;
 pub struct DaemonState {
     /// this is passed via env var STATE_FILE
     pub json_file_path: String,
-    /// What kind of network
-    pub kind: ChainKind,
-    /// Identifier for the network ex. columbus-2
-    pub chain_id: String,
     /// Deployment identifier
     pub deployment_id: String,
     /// gRPC channel
     pub grpc_channel: Channel,
-    /// Underlying network details
-    pub network: NetworkInfoOwned,
-    /// Max gas and denom info
-    pub gas_denom: Denom,
-    /// gas price
-    pub gas_price: f64,
-    /// Optional urls for custom functionality
-    pub lcd_url: Option<String>,
-    pub fcd_url: Option<String>,
+    /// Information about the chain
+    pub chain_data: ChainData,
 }
 
 impl DaemonState {
     pub async fn new(
-        chain_info: RegistryChainInfo,
+        mut chain_data: ChainData,
         deployment_id: String,
     ) -> Result<DaemonState, DaemonError> {
-        if chain_info.apis.grpc.is_empty() {
+        if chain_data.apis.grpc.is_empty() {
             return Err(DaemonError::GRPCListIsEmpty);
         }
 
-        log::info!("Found {} gRPC endpoints", chain_info.apis.grpc.len());
+        log::info!("Found {} gRPC endpoints", chain_data.apis.grpc.len());
 
         // find working grpc channel
         let grpc_channel =
-            GrpcChannel::connect(&chain_info.apis.grpc, &chain_info.chain_id).await?;
+            GrpcChannel::connect(&chain_data.apis.grpc, &chain_data.chain_id).await?;
 
         // check if STATE_FILE en var is configured, fail if not
         let mut json_file_path = env::var("STATE_FILE").expect("STATE_FILE is not set");
 
         // if the network we are connecting is a local kind, add it to the fn
-        if chain_info.network_type == ChainKind::Local.to_string() {
+        if chain_data.network_type == ChainKind::Local.to_string() {
             let name = Path::new(&json_file_path)
                 .file_stem()
                 .unwrap()
@@ -68,8 +61,8 @@ impl DaemonState {
         }
 
         // Try to get the standard fee token (probably shortest denom)
-        let shortest_denom_token = chain_info.fees.fee_tokens.iter().fold(
-            chain_info.fees.fee_tokens[0].clone(),
+        let shortest_denom_token = chain_data.fees.fee_tokens.iter().fold(
+            chain_data.fees.fee_tokens[0].clone(),
             |acc, item| {
                 if item.denom.len() < acc.denom.len() {
                     item.clone()
@@ -78,23 +71,15 @@ impl DaemonState {
                 }
             },
         );
+        // set a single fee token
+        chain_data.fees.fee_tokens = vec![shortest_denom_token];
 
         // build daemon state
         let state = DaemonState {
             json_file_path,
-            kind: ChainKind::from(chain_info.network_type),
             deployment_id,
             grpc_channel,
-            network: NetworkInfoOwned {
-                id: chain_info.chain_name.to_string(),
-                pub_address_prefix: chain_info.bech32_prefix,
-                coin_type: chain_info.slip44,
-            },
-            chain_id: chain_info.chain_id.to_string(),
-            gas_denom: Denom::from_str(&shortest_denom_token.denom).unwrap(),
-            gas_price: shortest_denom_token.fixed_min_gas_price,
-            lcd_url: None,
-            fcd_url: None,
+            chain_data,
         };
 
         log::info!(
@@ -105,8 +90,8 @@ impl DaemonState {
         // write json state file
         crate::daemon::json_file::write(
             &state.json_file_path,
-            &state.chain_id,
-            &state.network.id,
+            &state.chain_data.chain_id.to_string(),
+            &state.chain_data.chain_name,
             &state.deployment_id,
         );
 
@@ -118,8 +103,8 @@ impl DaemonState {
         self.deployment_id = deployment_id.into();
         crate::daemon::json_file::write(
             &self.json_file_path,
-            &self.chain_id,
-            &self.network.id,
+            &self.chain_data.chain_id.to_string(),
+            &self.chain_data.chain_name,
             &self.deployment_id,
         );
     }
@@ -132,14 +117,15 @@ impl DaemonState {
     /// Retrieve a stateful value using the chainId and networkId
     fn get(&self, key: &str) -> Value {
         let json = self.read_state();
-        json[&self.network.id][&self.chain_id.to_string()][key].clone()
+        json[&self.chain_data.chain_name][&self.chain_data.chain_id.to_string()][key].clone()
     }
 
     /// Set a stateful value using the chainId and networkId
     fn set<T: Serialize>(&self, key: &str, contract_id: &str, value: T) {
         let mut json = self.read_state();
 
-        json[&self.network.id][&self.chain_id.to_string()][key][contract_id] = json!(value);
+        json[&self.chain_data.chain_name][&self.chain_data.chain_id.to_string()][key]
+            [contract_id] = json!(value);
 
         serde_json::to_writer_pretty(File::create(&self.json_file_path).unwrap(), &json).unwrap();
     }
@@ -195,139 +181,5 @@ impl StateInterface for Rc<DaemonState> {
             store.insert(id.clone(), code_id.as_u64().unwrap());
         }
         Ok(store)
-    }
-}
-
-#[allow(clippy::from_over_into)]
-impl Into<RegistryChainInfo> for ChainInfo<'_> {
-    fn into(self) -> RegistryChainInfo {
-        RegistryChainInfo {
-            chain_name: self.network_info.id.to_string(),
-            chain_id: self.chain_id.to_string().into(),
-            bech32_prefix: self.network_info.pub_address_prefix.into(),
-            fees: FeeTokens {
-                fee_tokens: vec![FeeToken {
-                    fixed_min_gas_price: self.gas_price,
-                    denom: self.gas_denom.to_string(),
-                    ..Default::default()
-                }],
-            },
-            network_type: self.kind.to_string(),
-            apis: Apis {
-                grpc: self
-                    .grpc_urls
-                    .iter()
-                    .map(|url| Grpc {
-                        address: url.to_string(),
-                        ..Default::default()
-                    })
-                    .collect(),
-                ..Default::default()
-            },
-            slip44: self.network_info.coin_type,
-            ..Default::default()
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ChainInfo<'a> {
-    /// Identifier for the network ex. columbus-2
-    pub chain_id: &'a str,
-    /// Max gas and denom info
-    // #[serde(with = "cosm_denom_format")]
-    pub gas_denom: &'a str,
-    /// gas price
-    pub gas_price: f64,
-    pub grpc_urls: &'a [&'a str],
-    /// Optional urls for custom functionality
-    pub lcd_url: Option<&'a str>,
-    pub fcd_url: Option<&'a str>,
-    pub network_info: NetworkInfo<'a>,
-    pub kind: ChainKind,
-}
-
-#[derive(Clone, Debug, Serialize, Default)]
-pub struct NetworkInfo<'a> {
-    pub id: &'a str,
-    /// address prefix
-    pub pub_address_prefix: &'a str,
-    /// coin type for key derivation
-    pub coin_type: u32,
-}
-
-#[derive(Clone, Debug, Serialize, Default)]
-pub struct NetworkInfoOwned {
-    pub id: String,
-    /// address prefix
-    pub pub_address_prefix: String,
-    /// coin type for key derivation
-    pub coin_type: u32,
-}
-
-impl From<NetworkInfo<'_>> for NetworkInfoOwned {
-    fn from(info: NetworkInfo<'_>) -> Self {
-        Self {
-            id: info.id.to_owned(),
-            pub_address_prefix: info.pub_address_prefix.to_owned(),
-            coin_type: info.coin_type,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ChainKind {
-    Local,
-    Mainnet,
-    Testnet,
-}
-
-impl ChainKind {
-    pub fn new() -> Result<Self, CwOrchError> {
-        let network_id = env::var("NETWORK").expect("NETWORK is not set");
-        let network = match network_id.as_str() {
-            "testnet" => ChainKind::Testnet,
-            "mainnet" => ChainKind::Mainnet,
-            _ => ChainKind::Local,
-        };
-        Ok(network)
-    }
-
-    pub fn mnemonic_name(&self) -> &str {
-        match *self {
-            ChainKind::Local => "LOCAL_MNEMONIC",
-            ChainKind::Testnet => "TEST_MNEMONIC",
-            ChainKind::Mainnet => "MAIN_MNEMONIC",
-        }
-    }
-
-    pub fn multisig_name(&self) -> &str {
-        match *self {
-            ChainKind::Local => "LOCAL_MULTISIG",
-            ChainKind::Testnet => "TEST_MULTISIG",
-            ChainKind::Mainnet => "MAIN_MULTISIG",
-        }
-    }
-}
-
-impl ToString for ChainKind {
-    fn to_string(&self) -> String {
-        match *self {
-            ChainKind::Local => "local",
-            ChainKind::Testnet => "testnet",
-            ChainKind::Mainnet => "mainnet",
-        }
-        .into()
-    }
-}
-
-impl From<String> for ChainKind {
-    fn from(str: String) -> Self {
-        match str.as_str() {
-            "local" => ChainKind::Local,
-            "testnet" => ChainKind::Testnet,
-            "mainnet" => ChainKind::Mainnet,
-            _ => ChainKind::Local,
-        }
     }
 }


### PR DESCRIPTION
This PR cleans up the `DaemonState` struct by removing all the chain-specific data and keeping it in a `chain_data` field that holds a `ChainData` struct, imported from chain registry. This way we can remove the owned chain data structs and we improve readability and maintainability. 