### PR TITLE
Include `new` fn in `interface` macro

### DIFF
--- a/cw-orch/tests/interface_macro.rs
+++ b/cw-orch/tests/interface_macro.rs
@@ -25,12 +25,6 @@ const MOCK_CONTRACT_WASM: &str = "../artifacts/mock_contract.wasm";
 #[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
 pub struct MockContract;
 
-impl<Chain: CwEnv> MockContract<Chain> {
-    pub fn new(id: &str, chain: Chain) -> Self {
-        Self(Contract::new(id, chain))
-    }
-}
-
 impl<Chain: CwEnv> Uploadable for MockContract<Chain> {
     fn wasm(&self) -> <Daemon as TxHandler>::ContractSource {
         // create contract base configuration

--- a/packages/cw-orch-contract-derive/src/lib.rs
+++ b/packages/cw-orch-contract-derive/src/lib.rs
@@ -154,11 +154,7 @@ pub fn interface(attrs: TokenStream, input: TokenStream) -> TokenStream {
 
     let all_phantom_marker_values: Vec<TokenStream2> = all_generics
         .iter()
-        .map(|_| {
-            quote!(
-                ::std::marker::PhantomData::default()
-            )
-        })
+        .map(|_| quote!(::std::marker::PhantomData::default()))
         .collect();
 
     // We create necessary Debug + Serialize traits


### PR DESCRIPTION
Add a  fn implementation to the interface macro. This way the developer doesn't have to define it themselves.