### PR TITLE
Remove ChainUpload and Mock generics

### DIFF
--- a/cw-orch/examples/daemon_test.rs
+++ b/cw-orch/examples/daemon_test.rs
@@ -3,7 +3,7 @@ use counter_contract::{
     msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg},
 };
 use cw_orch::prelude::{
-    networks, ContractInstance, CwOrcExecute, CwOrcInstantiate, CwOrcQuery, CwOrcUpload, Daemon,
+    networks, ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Daemon,
     TxHandler,
 };
 use tokio::runtime::Runtime;

--- a/cw-orch/examples/daemon_test.rs
+++ b/cw-orch/examples/daemon_test.rs
@@ -3,8 +3,8 @@ use counter_contract::{
     msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg},
 };
 use cw_orch::prelude::{
-    networks, ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Daemon,
-    TxHandler,
+    networks, ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload,
+    Daemon, TxHandler,
 };
 use tokio::runtime::Runtime;
 const LOCAL_MNEMONIC: &str = "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose";

--- a/cw-orch/examples/mock_test.rs
+++ b/cw-orch/examples/mock_test.rs
@@ -4,7 +4,7 @@ use counter_contract::{
     contract::CounterContract,
     msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg},
 };
-use cw_orch::prelude::{CwOrcExecute, CwOrcInstantiate, CwOrcQuery, CwOrcUpload, Mock};
+use cw_orch::prelude::{CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Mock};
 
 pub fn main() {
     let sender = Addr::unchecked("juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y");

--- a/cw-orch/src/daemon/sync/core.rs
+++ b/cw-orch/src/daemon/sync/core.rs
@@ -4,7 +4,8 @@ use crate::{
     environment::{ChainUpload, TxHandler},
     prelude::{
         queriers::{CosmWasm, DaemonQuerier},
-        CallAs, ContractInstance, CwOrchExecute, DaemonBuilder, IndexResponse, Uploadable, WasmPath,
+        CallAs, ContractInstance, CwOrchExecute, DaemonBuilder, IndexResponse, Uploadable,
+        WasmPath,
     },
     state::ChainState,
 };

--- a/cw-orch/src/daemon/sync/core.rs
+++ b/cw-orch/src/daemon/sync/core.rs
@@ -4,7 +4,7 @@ use crate::{
     environment::{ChainUpload, TxHandler},
     prelude::{
         queriers::{CosmWasm, DaemonQuerier},
-        CallAs, ContractInstance, CwOrcExecute, DaemonBuilder, IndexResponse, Uploadable, WasmPath,
+        CallAs, ContractInstance, CwOrchExecute, DaemonBuilder, IndexResponse, Uploadable, WasmPath,
     },
     state::ChainState,
 };
@@ -222,7 +222,7 @@ impl ChainUpload for Daemon {
     }
 }
 
-impl<T: CwOrcExecute<Daemon> + ContractInstance<Daemon> + Clone> CallAs<Daemon> for T {
+impl<T: CwOrchExecute<Daemon> + ContractInstance<Daemon> + Clone> CallAs<Daemon> for T {
     type Sender = Wallet;
 
     fn set_sender(&mut self, sender: &Self::Sender) {

--- a/cw-orch/src/daemon/traits.rs
+++ b/cw-orch/src/daemon/traits.rs
@@ -3,7 +3,7 @@ use crate::{daemon::queriers::CosmWasm, environment::TxResponse, error::CwOrchEr
 use super::sync::Daemon;
 
 /// Helper methods for conditional uploading of a contract.
-pub trait ConditionalUpload: CwOrcUpload<Daemon> {
+pub trait ConditionalUpload: CwOrchUpload<Daemon> {
     /// Only upload the contract if it is not uploaded yet (checksum does not match)
     fn upload_if_needed(&self) -> Result<Option<TxResponse<Daemon>>, CwOrchError> {
         if self.latest_is_uploaded()? {
@@ -45,10 +45,10 @@ pub trait ConditionalUpload: CwOrcUpload<Daemon> {
     }
 }
 
-impl<T> ConditionalUpload for T where T: CwOrcUpload<Daemon> {}
+impl<T> ConditionalUpload for T where T: CwOrchUpload<Daemon> {}
 
 /// Helper methods for conditional migration of a contract.
-pub trait ConditionalMigrate: CwOrcMigrate<Daemon> + ConditionalUpload {
+pub trait ConditionalMigrate: CwOrchMigrate<Daemon> + ConditionalUpload {
     /// Only migrate the contract if it is not on the latest code-id yet
     fn migrate_if_needed(
         &self,
@@ -63,4 +63,4 @@ pub trait ConditionalMigrate: CwOrcMigrate<Daemon> + ConditionalUpload {
     }
 }
 
-impl<T> ConditionalMigrate for T where T: CwOrcMigrate<Daemon> + CwOrcUpload<Daemon> {}
+impl<T> ConditionalMigrate for T where T: CwOrchMigrate<Daemon> + CwOrchUpload<Daemon> {}

--- a/cw-orch/src/deploy.rs
+++ b/cw-orch/src/deploy.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 ///
 /// ## Example:
 /// ```ignore
-/// use cw_orch::{Deploy, CwOrchError, Empty, CwEnv, CwOrcUpload};
+/// use cw_orch::{Deploy, CwOrchError, Empty, CwEnv, CwOrchUpload};
 /// use cw_plus_orchestrate::Cw20Base;
 /// use cw20::Cw20Coin;
 ///

--- a/cw-orch/src/environment.rs
+++ b/cw-orch/src/environment.rs
@@ -13,8 +13,8 @@ use std::fmt::Debug;
 pub type TxResponse<Chain> = <Chain as TxHandler>::Response;
 
 /// Signals a supported execution environment for CosmWasm contracts
-pub trait CwEnv: TxHandler + ChainUpload + Clone {}
-impl<T: TxHandler + ChainUpload + Clone> CwEnv for T {}
+pub trait CwEnv: TxHandler + Clone {}
+impl<T: TxHandler + Clone> CwEnv for T {}
 
 /// Signer trait for chains.
 /// Accesses the sender information from the chain object to perform actions.
@@ -42,13 +42,9 @@ pub trait TxHandler: ChainState + Clone {
     fn block_info(&self) -> Result<BlockInfo, Self::Error>;
 
     // Actions
-    /// Send a ExecMsg to a contract.
-    fn execute<E: Serialize + Debug>(
-        &self,
-        exec_msg: &E,
-        coins: &[Coin],
-        contract_address: &Addr,
-    ) -> Result<Self::Response, Self::Error>;
+
+    /// Uploads a contract to the chain.
+    fn upload(&self, contract_source: &impl Uploadable) -> Result<Self::Response, Self::Error>;
 
     /// Send a InstantiateMsg to a contract.
     fn instantiate<I: Serialize + Debug>(
@@ -58,6 +54,13 @@ pub trait TxHandler: ChainState + Clone {
         label: Option<&str>,
         admin: Option<&Addr>,
         coins: &[cosmwasm_std::Coin],
+    ) -> Result<Self::Response, Self::Error>;
+    /// Send a ExecMsg to a contract.
+    fn execute<E: Serialize + Debug>(
+        &self,
+        exec_msg: &E,
+        coins: &[Coin],
+        contract_address: &Addr,
     ) -> Result<Self::Response, Self::Error>;
 
     /// Send a QueryMsg to a contract.
@@ -74,11 +77,4 @@ pub trait TxHandler: ChainState + Clone {
         new_code_id: u64,
         contract_address: &Addr,
     ) -> Result<Self::Response, Self::Error>;
-}
-
-// Required to be a different trait because it can not be implemented for the generic Mock<...>.
-/// Uploads a contract to the chain.
-pub trait ChainUpload: TxHandler {
-    /// Uploads a contract to the chain.
-    fn upload(&self, contract_source: &impl Uploadable) -> Result<Self::Response, Self::Error>;
 }

--- a/cw-orch/src/interface_traits.rs
+++ b/cw-orch/src/interface_traits.rs
@@ -1,6 +1,5 @@
 use crate::{
     contract::Contract,
-    environment::ChainUpload,
     error::CwOrchError,
     prelude::{CwEnv, WasmPath},
 };
@@ -168,9 +167,7 @@ pub trait Uploadable {
 }
 
 /// Trait that indicates that the contract can be uploaded.
-pub trait CwOrchUpload<Chain: CwEnv + ChainUpload>:
-    ContractInstance<Chain> + Uploadable + Sized
-{
+pub trait CwOrchUpload<Chain: CwEnv>: ContractInstance<Chain> + Uploadable + Sized {
     /// upload the contract to the configured environment.
     fn upload(&self) -> Result<Chain::Response, CwOrchError> {
         self.as_instance().upload(self)
@@ -178,10 +175,7 @@ pub trait CwOrchUpload<Chain: CwEnv + ChainUpload>:
 }
 
 /// enable `.upload()` for contracts that implement `Uploadable` for that environment.
-impl<T: ContractInstance<Chain> + Uploadable, Chain: CwEnv + ChainUpload> CwOrchUpload<Chain>
-    for T
-{
-}
+impl<T: ContractInstance<Chain> + Uploadable, Chain: CwEnv> CwOrchUpload<Chain> for T {}
 
 /// Enables calling a contract with a different sender.
 ///

--- a/cw-orch/src/interface_traits.rs
+++ b/cw-orch/src/interface_traits.rs
@@ -178,7 +178,10 @@ pub trait CwOrchUpload<Chain: CwEnv + ChainUpload>:
 }
 
 /// enable `.upload()` for contracts that implement `Uploadable` for that environment.
-impl<T: ContractInstance<Chain> + Uploadable, Chain: CwEnv + ChainUpload> CwOrchUpload<Chain> for T {}
+impl<T: ContractInstance<Chain> + Uploadable, Chain: CwEnv + ChainUpload> CwOrchUpload<Chain>
+    for T
+{
+}
 
 /// Enables calling a contract with a different sender.
 ///

--- a/cw-orch/src/interface_traits.rs
+++ b/cw-orch/src/interface_traits.rs
@@ -93,7 +93,7 @@ pub trait MigratableContract {
 }
 
 /// Smart contract execute entry point.
-pub trait CwOrcExecute<Chain: CwEnv>: ExecutableContract + ContractInstance<Chain> {
+pub trait CwOrchExecute<Chain: CwEnv>: ExecutableContract + ContractInstance<Chain> {
     /// Send a ExecuteMsg to the contract.
     fn execute(
         &self,
@@ -104,10 +104,10 @@ pub trait CwOrcExecute<Chain: CwEnv>: ExecutableContract + ContractInstance<Chai
     }
 }
 
-impl<T: ExecutableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrcExecute<Chain> for T {}
+impl<T: ExecutableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrchExecute<Chain> for T {}
 
 /// Smart contract instantiate entry point.
-pub trait CwOrcInstantiate<Chain: CwEnv>: InstantiableContract + ContractInstance<Chain> {
+pub trait CwOrchInstantiate<Chain: CwEnv>: InstantiableContract + ContractInstance<Chain> {
     /// Instantiates the contract.
     fn instantiate(
         &self,
@@ -120,13 +120,13 @@ pub trait CwOrcInstantiate<Chain: CwEnv>: InstantiableContract + ContractInstanc
     }
 }
 
-impl<T: InstantiableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrcInstantiate<Chain>
+impl<T: InstantiableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrchInstantiate<Chain>
     for T
 {
 }
 
 /// Smart contract query entry point.
-pub trait CwOrcQuery<Chain: CwEnv>: QueryableContract + ContractInstance<Chain> {
+pub trait CwOrchQuery<Chain: CwEnv>: QueryableContract + ContractInstance<Chain> {
     /// Query the contract.
     fn query<G: Serialize + DeserializeOwned + Debug>(
         &self,
@@ -136,10 +136,10 @@ pub trait CwOrcQuery<Chain: CwEnv>: QueryableContract + ContractInstance<Chain> 
     }
 }
 
-impl<T: QueryableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrcQuery<Chain> for T {}
+impl<T: QueryableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrchQuery<Chain> for T {}
 
 /// Smart contract migrate entry point.
-pub trait CwOrcMigrate<Chain: CwEnv>: MigratableContract + ContractInstance<Chain> {
+pub trait CwOrchMigrate<Chain: CwEnv>: MigratableContract + ContractInstance<Chain> {
     /// Migrate the contract.
     fn migrate(
         &self,
@@ -150,7 +150,7 @@ pub trait CwOrcMigrate<Chain: CwEnv>: MigratableContract + ContractInstance<Chai
     }
 }
 
-impl<T: MigratableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrcMigrate<Chain> for T {}
+impl<T: MigratableContract + ContractInstance<Chain>, Chain: CwEnv> CwOrchMigrate<Chain> for T {}
 
 /// Trait to implement on the contract to enable it to be uploaded
 /// Should return [`WasmPath`](crate::prelude::WasmPath) for `Chain = Daemon`
@@ -168,7 +168,7 @@ pub trait Uploadable {
 }
 
 /// Trait that indicates that the contract can be uploaded.
-pub trait CwOrcUpload<Chain: CwEnv + ChainUpload>:
+pub trait CwOrchUpload<Chain: CwEnv + ChainUpload>:
     ContractInstance<Chain> + Uploadable + Sized
 {
     /// upload the contract to the configured environment.
@@ -178,12 +178,12 @@ pub trait CwOrcUpload<Chain: CwEnv + ChainUpload>:
 }
 
 /// enable `.upload()` for contracts that implement `Uploadable` for that environment.
-impl<T: ContractInstance<Chain> + Uploadable, Chain: CwEnv + ChainUpload> CwOrcUpload<Chain> for T {}
+impl<T: ContractInstance<Chain> + Uploadable, Chain: CwEnv + ChainUpload> CwOrchUpload<Chain> for T {}
 
 /// Enables calling a contract with a different sender.
 ///
 /// Clones the contract interface to prevent mutation of the original.
-pub trait CallAs<Chain: CwEnv>: CwOrcExecute<Chain> + ContractInstance<Chain> + Clone {
+pub trait CallAs<Chain: CwEnv>: CwOrchExecute<Chain> + ContractInstance<Chain> + Clone {
     /// The sender type for environment
     type Sender: Clone;
 

--- a/cw-orch/src/mock/core.rs
+++ b/cw-orch/src/mock/core.rs
@@ -327,7 +327,7 @@ impl ChainUpload for Mock {
     }
 }
 
-impl<T: CwOrcExecute<Mock> + ContractInstance<Mock> + Clone> CallAs<Mock> for T {
+impl<T: CwOrchExecute<Mock> + ContractInstance<Mock> + Clone> CallAs<Mock> for T {
     type Sender = Addr;
 
     fn set_sender(&mut self, sender: &Addr) {

--- a/cw-orch/src/prelude.rs
+++ b/cw-orch/src/prelude.rs
@@ -12,8 +12,8 @@
 
 // Contract traits
 pub use crate::interface_traits::{
-    CallAs, ContractInstance, CwOrcExecute, CwOrcInstantiate, CwOrcMigrate, CwOrcQuery,
-    CwOrcUpload, ExecutableContract, InstantiableContract, MigratableContract, QueryableContract,
+    CallAs, ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchMigrate, CwOrchQuery,
+    CwOrchUpload, ExecutableContract, InstantiableContract, MigratableContract, QueryableContract,
     Uploadable,
 };
 

--- a/cw-orch/tests/entry_point_macro.rs
+++ b/cw-orch/tests/entry_point_macro.rs
@@ -1,12 +1,12 @@
 use mock_contract::{ExecuteMsg, InstantiateMsg, MigrateMsg, MockContract, QueryMsg};
 
 use cosmwasm_std::Event;
-use cw_orch::prelude::{ContractInstance, CwOrcExecute, CwOrcMigrate, CwOrcQuery};
+use cw_orch::prelude::{ContractInstance, CwOrchExecute, CwOrchMigrate, CwOrchQuery};
 
-use cw_orch::prelude::CwOrcUpload;
+use cw_orch::prelude::CwOrchUpload;
 mod common;
 use cosmwasm_std::Addr;
-use cw_orch::prelude::{CwOrcInstantiate, Mock};
+use cw_orch::prelude::{CwOrchInstantiate, Mock};
 
 #[test]
 fn test_instantiate() {

--- a/cw-orch/tests/fns_macro.rs
+++ b/cw-orch/tests/fns_macro.rs
@@ -2,10 +2,10 @@ use mock_contract::{ExecuteMsgFns, InstantiateMsg, MockContract, QueryMsgFns};
 
 use cosmwasm_std::Event;
 
-use cw_orch::prelude::CwOrcUpload;
+use cw_orch::prelude::CwOrchUpload;
 mod common;
 use cosmwasm_std::Addr;
-use cw_orch::prelude::{CwOrcInstantiate, Mock};
+use cw_orch::prelude::{CwOrchInstantiate, Mock};
 
 #[test]
 fn test_execute() {

--- a/cw-orch/tests/interface_macro.rs
+++ b/cw-orch/tests/interface_macro.rs
@@ -9,7 +9,7 @@ use mock_contract::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 use cosmwasm_std::Event;
 use cw_orch::prelude::{
-    ContractInstance, CwOrcExecute, CwOrcInstantiate, CwOrcMigrate, CwOrcQuery, CwOrcUpload,
+    ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchMigrate, CwOrchQuery, CwOrchUpload,
     Daemon, Mock,
 };
 

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -66,7 +66,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
                         let msg = #name::#variant_name {
                             #(#variant_ident_content_names,)*
                         };
-                        <Self as ::cw_orch::prelude::CwOrcExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
+                        <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
                     }
                 ))
             }
@@ -74,7 +74,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
     });
 
     let derived_trait = quote!(
-        pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrcExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics #where_clause> {
+        pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics #where_clause> {
             #(#variant_fns)*
         }
     );
@@ -83,7 +83,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
         #[automatically_derived]
         impl<SupportedContract, Chain: ::cw_orch::prelude::CwEnv, #type_generics> #bname<Chain, #type_generics> for SupportedContract
         where
-            SupportedContract: ::cw_orch::prelude::CwOrcExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics #where_clause>{}
+            SupportedContract: ::cw_orch::prelude::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics #where_clause>{}
     );
 
     let expand = quote!(

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -64,7 +64,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
     );
 
     let derived_trait = quote!(
-        pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrcQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics #where_clause> {
+        pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics #where_clause> {
             #(#variant_fns)*
         }
     );
@@ -72,7 +72,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
     let derived_trait_impl = quote!(
         impl<SupportedContract, Chain: ::cw_orch::prelude::CwEnv, #type_generics> #bname<Chain, #type_generics> for SupportedContract
         where
-            SupportedContract: ::cw_orch::prelude::CwOrcQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics #where_clause>{}
+            SupportedContract: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics #where_clause>{}
     );
 
     let expand = quote!(


### PR DESCRIPTION
Removes the chainupload trait because it could be included in the TxHandler. This caused issues for the TxHandler implementation of the Mock as the trait could not be implemented for the generic Mock. We already came to the agreement that custom bindings are not the path forward with this crate or the Abstract framework. Hence I discided to remove them.