### PR TITLE
Refactor tx construction and add insufficient fee fallback

### DIFF
--- a/cw-orch/src/daemon/error.rs
+++ b/cw-orch/src/daemon/error.rs
@@ -102,6 +102,8 @@ pub enum DaemonError {
     BuilderMissing(String),
     #[error("ibc error: {0}")]
     IbcError(String),
+    #[error("insufficient fee, check gas price: {0}")]
+    InsufficientFee(String),
 }
 
 impl DaemonError {

--- a/cw-orch/src/daemon/mod.rs
+++ b/cw-orch/src/daemon/mod.rs
@@ -25,6 +25,7 @@ pub use self::{
     tx_resp::*,
 };
 pub use sender::Wallet;
+pub use tx_builder::TxBuilder;
 
 pub(crate) mod cosmos_modules {
     pub use cosmrs::proto::{

--- a/cw-orch/src/daemon/mod.rs
+++ b/cw-orch/src/daemon/mod.rs
@@ -18,6 +18,7 @@ mod tx_resp;
 // expose these as mods as they can grow
 pub mod networks;
 pub mod queriers;
+pub(crate) mod tx_builder;
 
 pub use self::{
     builder::*, chain_info::*, channel::*, core::*, error::*, state::*, sync::*, traits::*,

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -40,7 +40,7 @@ pub const JUNO_1: ChainInfo = ChainInfo {
     gas_denom: "ujuno",
     gas_price: 0.0750,
     grpc_urls: &[
-        "http://grpc-juno-ia.cosmosia.notional.ventures:443",
+        "https://grpc-juno-ia.cosmosia.notional.ventures",
         "http://juno-grpc.polkachu.com:12690",
     ],
     network_info: JUNO_NETWORK,

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -40,7 +40,7 @@ pub const JUNO_1: ChainInfo = ChainInfo {
     gas_denom: "ujuno",
     gas_price: 0.0750,
     grpc_urls: &[
-        "https://grpc-juno-ia.cosmosia.notional.ventures:443",
+        "http://grpc-juno-ia.cosmosia.notional.ventures:443",
         "http://juno-grpc.polkachu.com:12690",
     ],
     network_info: JUNO_NETWORK,

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -39,7 +39,10 @@ pub const JUNO_1: ChainInfo = ChainInfo {
     chain_id: "juno-1",
     gas_denom: "ujuno",
     gas_price: 0.0750,
-    grpc_urls: &["https://grpc-juno-ia.cosmosia.notional.ventures:443","http://juno-grpc.polkachu.com:12690"],
+    grpc_urls: &[
+        "https://grpc-juno-ia.cosmosia.notional.ventures:443",
+        "http://juno-grpc.polkachu.com:12690",
+    ],
     network_info: JUNO_NETWORK,
     lcd_url: None,
     fcd_url: None,

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -1,5 +1,7 @@
 use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
+// https://notional.ventures/resources/endpoints#juno
+
 pub const JUNO_NETWORK: NetworkInfo = NetworkInfo {
     id: "juno",
     pub_address_prefix: "juno",
@@ -37,7 +39,7 @@ pub const JUNO_1: ChainInfo = ChainInfo {
     chain_id: "juno-1",
     gas_denom: "ujuno",
     gas_price: 0.0750,
-    grpc_urls: &["http://juno-grpc.polkachu.com:12690"],
+    grpc_urls: &["https://grpc-juno-ia.cosmosia.notional.ventures:443","http://juno-grpc.polkachu.com:12690"],
     network_info: JUNO_NETWORK,
     lcd_url: None,
     fcd_url: None,

--- a/cw-orch/src/daemon/networks/terra.rs
+++ b/cw-orch/src/daemon/networks/terra.rs
@@ -22,7 +22,7 @@ pub const PHOENIX_1: ChainInfo = ChainInfo {
     chain_id: "phoenix-1",
     gas_denom: "uluna",
     gas_price: 0.15,
-    grpc_urls: &["https://terra-grpc.polkachu.com:11790"],
+    grpc_urls: &["http://terra-grpc.polkachu.com:11790"],
     network_info: TERRA_NETWORK,
     lcd_url: None,
     fcd_url: None,

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -237,7 +237,7 @@ impl Sender<All> {
             .await?;
 
         let commit = commit.into_inner().tx_response.unwrap();
-        return Ok(commit);
+        Ok(commit)
     }
 }
 

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -121,7 +121,7 @@ impl Sender<All> {
         let fee = TxBuilder::build_fee(
             0u8,
             &self.daemon_state.chain_data.fees.fee_tokens[0].denom,
-            None,
+            0,
         );
 
         let auth_info =

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -18,7 +18,7 @@ use cosmrs::{
 };
 use cosmwasm_std::Addr;
 use secp256k1::{All, Context, Secp256k1, Signing};
-use std::{convert::TryFrom, env, rc::Rc, str::FromStr};
+use std::{convert::TryFrom, env, rc::Rc, str::FromStr, time::Duration};
 
 use tonic::transport::Channel;
 
@@ -172,6 +172,8 @@ impl Sender<All> {
 
             // update the fee and try again
             let tx = tx_builder.fee_amount(new_fee).build(self).await?;
+            // wait a bit 
+            tokio::time::sleep(Duration::from_millis(10000)).await;
 
             tx_response = self.broadcast_tx(tx).await?;
         }

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -13,12 +13,12 @@ use cosmrs::{
     crypto::secp256k1::SigningKey,
     proto::traits::Message,
     tendermint::chain::Id,
-    tx::{self, Fee, Msg, Raw, SequenceNumber, SignDoc, SignerInfo},
-    AccountId, Any, Coin,
+    tx::{self, Msg, Raw, SignDoc, SignerInfo},
+    AccountId,
 };
 use cosmwasm_std::Addr;
 use secp256k1::{All, Context, Secp256k1, Signing};
-use std::{convert::TryFrom, env, rc::Rc, str::FromStr, time::Duration};
+use std::{convert::TryFrom, env, rc::Rc, str::FromStr};
 
 use tonic::transport::Channel;
 
@@ -171,9 +171,8 @@ impl Sender<All> {
             };
 
             // update the fee and try again
-            let tx = tx_builder.fee_amount(new_fee).build(self).await?;
-            // wait a bit
-            tokio::time::sleep(Duration::from_millis(10000)).await;
+            tx_builder.fee_amount(new_fee);
+            let tx = tx_builder.build(self).await?;
 
             tx_response = self.broadcast_tx(tx).await?;
         }

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -172,7 +172,7 @@ impl Sender<All> {
 
             // update the fee and try again
             let tx = tx_builder.fee_amount(new_fee).build(self).await?;
-            // wait a bit 
+            // wait a bit
             tokio::time::sleep(Duration::from_millis(10000)).await;
 
             tx_response = self.broadcast_tx(tx).await?;

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -231,7 +231,7 @@ impl Sender<All> {
         let commit = client
             .broadcast_tx(cosmos_modules::tx::BroadcastTxRequest {
                 tx_bytes: tx.to_bytes()?,
-                mode: cosmos_modules::tx::BroadcastMode::Block.into(),
+                mode: cosmos_modules::tx::BroadcastMode::Sync.into(),
             })
             .await?;
 

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -158,6 +158,8 @@ impl Sender<All> {
 
         let mut tx_response = self.broadcast_tx(tx).await?;
 
+        log::debug!("tx broadcast response: {:?}", tx_response);
+
         if has_insufficient_fee(&tx_response.raw_log) {
             // get the suggested fee from the error message
             let suggested_fee = parse_suggested_fee(&tx_response.raw_log);

--- a/cw-orch/src/daemon/sender.rs
+++ b/cw-orch/src/daemon/sender.rs
@@ -4,6 +4,7 @@ use super::{
     error::DaemonError,
     queriers::{DaemonQuerier, Node},
     state::DaemonState,
+    tx_builder::TxBuilder,
     tx_resp::CosmTxResponse,
 };
 use crate::{daemon::core::parse_cw_coins, keys::private::PrivateKey};
@@ -12,7 +13,7 @@ use cosmrs::{
     crypto::secp256k1::SigningKey,
     proto::traits::Message,
     tendermint::chain::Id,
-    tx::{self, Fee, Msg, Raw, SignDoc, SignerInfo},
+    tx::{self, Fee, Msg, Raw, SequenceNumber, SignDoc, SignerInfo},
     AccountId, Any, Coin,
 };
 use cosmwasm_std::Addr;
@@ -20,9 +21,6 @@ use secp256k1::{All, Context, Secp256k1, Signing};
 use std::{convert::TryFrom, env, rc::Rc, str::FromStr};
 
 use tonic::transport::Channel;
-
-const GAS_LIMIT: u64 = 1_000_000;
-const GAS_BUFFER: f64 = 1.2;
 
 /// A wallet is a sender of transactions, can be safely cloned and shared within the same thread.
 pub type Wallet = Rc<Sender<All>>;
@@ -32,7 +30,7 @@ pub type Wallet = Rc<Sender<All>>;
 pub struct Sender<C: Signing + Context> {
     pub private_key: SigningKey,
     pub secp: Secp256k1<C>,
-    daemon_state: Rc<DaemonState>,
+    pub(crate) daemon_state: Rc<DaemonState>,
 }
 
 impl Sender<All> {
@@ -114,38 +112,17 @@ impl Sender<All> {
         self.commit_tx(vec![msg_send], Some("sending tokens")).await
     }
 
-    pub(crate) fn build_tx_body<T: Msg>(
-        &self,
-        msgs: Vec<T>,
-        memo: Option<&str>,
-        timeout: u64,
-    ) -> tx::Body {
-        let msgs = msgs
-            .into_iter()
-            .map(Msg::into_any)
-            .collect::<Result<Vec<Any>, _>>()
-            .unwrap();
-
-        tx::Body::new(msgs, memo.unwrap_or_default(), timeout as u32)
-    }
-
-    pub(crate) fn build_fee(&self, amount: impl Into<u128>, gas_limit: Option<u64>) -> Fee {
-        let fee = Coin::new(
-            amount.into(),
-            &self.daemon_state.chain_data.fees.fee_tokens[0].denom,
-        )
-        .unwrap();
-        let gas = gas_limit.unwrap_or(GAS_LIMIT);
-        Fee::from_amount_and_gas(fee, gas)
-    }
-
     pub async fn calculate_gas(
         &self,
         tx_body: &tx::Body,
         sequence: u64,
         account_number: u64,
     ) -> Result<u64, DaemonError> {
-        let fee = self.build_fee(0u8, None);
+        let fee = TxBuilder::build_fee(
+            0u8,
+            &self.daemon_state.chain_data.fees.fee_tokens[0].denom,
+            None,
+        );
 
         let auth_info =
             SignerInfo::single_direct(Some(self.private_key.public_key()), sequence).auth_info(fee);
@@ -171,41 +148,46 @@ impl Sender<All> {
     ) -> Result<CosmTxResponse, DaemonError> {
         let timeout_height = Node::new(self.channel()).block_height().await? + 10u64;
 
-        let BaseAccount {
-            account_number,
-            sequence,
-            ..
-        } = self.base_account().await?;
+        let tx_body = TxBuilder::build_body(msgs, memo, timeout_height);
 
-        let tx_body = self.build_tx_body(msgs, memo, timeout_height);
+        let mut tx_builder = TxBuilder::new(tx_body);
 
-        let sim_gas_used = self
-            .calculate_gas(&tx_body, sequence, account_number)
+        // now commit and check the result, if we get an insufficient fee error, we can try again with the proposed fee
+
+        let tx = tx_builder.build(self).await?;
+
+        let mut tx_response = self.broadcast_tx(tx).await?;
+
+        if has_insufficient_fee(&tx_response.raw_log) {
+            // get the suggested fee from the error message
+            let suggested_fee = parse_suggested_fee(&tx_response.raw_log);
+
+            let Some(new_fee) = suggested_fee else {
+                return Err(DaemonError::InsufficientFee(
+                    tx_response.raw_log,
+                ));
+            };
+
+            // update the fee and try again
+            let tx = tx_builder.fee_amount(new_fee).build(self).await?;
+
+            tx_response = self.broadcast_tx(tx).await?;
+        }
+
+        let resp = Node::new(self.channel())
+            .find_tx(tx_response.txhash)
             .await?;
 
-        log::debug!("Simulated gas needed {:?}", sim_gas_used);
-
-        let gas_expected = sim_gas_used as f64 * GAS_BUFFER;
-        let amount_to_pay = gas_expected
-            * (self.daemon_state.chain_data.fees.fee_tokens[0].fixed_min_gas_price + 0.00001);
-
-        log::debug!("Calculated gas needed: {:?}", amount_to_pay);
-
-        let fee = self.build_fee(amount_to_pay as u128, Some(gas_expected as u64));
-
-        let auth_info =
-            SignerInfo::single_direct(Some(self.private_key.public_key()), sequence).auth_info(fee);
-
-        let sign_doc = SignDoc::new(
-            &tx_body,
-            &auth_info,
-            &Id::try_from(self.daemon_state.chain_data.chain_id.to_string())?,
-            account_number,
-        )?;
-
-        let tx_raw = sign_doc.sign(&self.private_key)?;
-
-        self.broadcast(tx_raw).await
+        // if tx result != 0 then the tx failed, so we return an error
+        // if tx result == 0 then the tx succeeded, so we return the tx response
+        if resp.code == 0 {
+            Ok(resp)
+        } else {
+            Err(DaemonError::TxFailed {
+                code: resp.code,
+                reason: resp.raw_log,
+            })
+        }
     }
 
     // TODO: this does not work for injective because it's eth account
@@ -239,7 +221,10 @@ impl Sender<All> {
         Ok(acc)
     }
 
-    async fn broadcast(&self, tx: Raw) -> Result<CosmTxResponse, DaemonError> {
+    async fn broadcast_tx(
+        &self,
+        tx: Raw,
+    ) -> Result<cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse, DaemonError> {
         let mut client = cosmos_modules::tx::service_client::ServiceClient::new(self.channel());
         let commit = client
             .broadcast_tx(cosmos_modules::tx::BroadcastTxRequest {
@@ -248,21 +233,61 @@ impl Sender<All> {
             })
             .await?;
 
-        log::debug!("{:?}", commit);
+        let commit = commit.into_inner().tx_response.unwrap();
+        return Ok(commit);
+    }
+}
 
-        let resp = Node::new(self.channel())
-            .find_tx(commit.into_inner().tx_response.unwrap().txhash)
-            .await?;
+fn has_insufficient_fee(raw_log: &str) -> bool {
+    raw_log.contains("insufficient fees")
+}
 
-        // if tx result != 0 then the tx failed, so we return an error
-        // if tx result == 0 then the tx succeeded, so we return the tx response
-        if resp.code == 0 {
-            Ok(resp)
-        } else {
-            Err(DaemonError::TxFailed {
-                code: resp.code,
-                reason: resp.raw_log,
-            })
-        }
+// from logs: "insufficient fees; got: 14867ujuno
+// required: 17771ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9,444255ujuno: insufficient fee"
+fn parse_suggested_fee(raw_log: &str) -> Option<u128> {
+    // Step 1: Split the log message into "got" and "required" parts.
+    let parts: Vec<&str> = raw_log.split("required: ").collect();
+
+    // Make sure the log message is in the expected format.
+    if parts.len() != 2 {
+        return None;
+    }
+
+    // Step 2: Split the "got" part to extract the paid fee and denomination.
+    let got_parts: Vec<&str> = parts[0].split_whitespace().collect();
+
+    // Extract the paid fee and denomination.
+    let paid_fee_with_denom = got_parts.last()?;
+    let (_, denomination) =
+        paid_fee_with_denom.split_at(paid_fee_with_denom.find(|c: char| !c.is_numeric())?);
+
+    eprintln!("denom: {}", denomination);
+
+    // Step 3: Iterate over each fee in the "required" part.
+    let required_fees: Vec<&str> = parts[1].split(denomination).collect();
+
+    eprintln!("required fees: {:?}", required_fees);
+
+    // read until the first non-numeric character backwards on the first string
+    let (_, suggested_fee) =
+        required_fees[0].split_at(required_fees[0].rfind(|c: char| !c.is_numeric())?);
+    eprintln!("suggested fee: {}", suggested_fee);
+
+    // remove the first character if parsing errors, which can be a comma
+    suggested_fee
+        .parse::<u128>()
+        .ok()
+        .or(suggested_fee[1..].parse::<u128>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_suggested_fee() {
+        let log = "insufficient fees; got: 14867ujuno required: 17771ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9,444255ujuno: insufficient fee";
+        let fee = parse_suggested_fee(log).unwrap();
+        assert_eq!(fee, 444255);
     }
 }

--- a/cw-orch/src/daemon/tx_builder.rs
+++ b/cw-orch/src/daemon/tx_builder.rs
@@ -85,8 +85,10 @@ impl TxBuilder {
         let sequence = self.sequence.unwrap_or(sequence);
 
         //
-        let (tx_fee, gas_limit) = if let (Some(fee),Some(gas_limit)) = (self.fee_amount ,self.gas_limit){
-            (fee,gas_limit)
+        let (tx_fee, gas_limit) = if let (Some(fee), Some(gas_limit)) =
+            (self.fee_amount, self.gas_limit)
+        {
+            (fee, gas_limit)
         } else {
             let sim_gas_used = wallet
                 .calculate_gas(&self.body, sequence, account_number)

--- a/cw-orch/src/daemon/tx_builder.rs
+++ b/cw-orch/src/daemon/tx_builder.rs
@@ -1,0 +1,123 @@
+use cosmrs::{
+    proto::cosmos::{auth::v1beta1::BaseAccount, tx::v1beta1::TxRaw},
+    tendermint::chain::Id,
+    tx::{self, Body, Fee, Msg, Raw, SequenceNumber, SignDoc, SignerInfo},
+    Any, Coin,
+};
+use secp256k1::All;
+
+use super::{sender::Sender, DaemonError, Wallet};
+
+const GAS_BUFFER: f64 = 1.2;
+const GAS_LIMIT: u64 = 2_000_000;
+
+/// Struct used to build a raw transaction and broadcast it with a sender.
+pub struct TxBuilder {
+    // # Required
+    pub(crate) body: Body,
+    // # Optional
+    pub(crate) fee_amount: Option<u128>,
+    pub(crate) gas_limit: Option<u64>,
+    // if defined, use this sequence, else get it from the node
+    pub(crate) sequence: Option<SequenceNumber>,
+}
+
+impl TxBuilder {
+    pub fn new(body: Body) -> Self {
+        Self {
+            body,
+            fee_amount: None,
+            gas_limit: None,
+            sequence: None,
+        }
+    }
+
+    pub fn body(&mut self, body: Body) -> &mut Self {
+        self.body = body;
+        self
+    }
+
+    pub fn fee_amount(&mut self, fee_amount: u128) -> &mut Self {
+        self.fee_amount = Some(fee_amount);
+        self
+    }
+
+    pub fn gas_limit(&mut self, gas_limit: u64) -> &mut Self {
+        self.gas_limit = Some(gas_limit);
+        self
+    }
+
+    pub fn sequence(&mut self, sequence: u64) -> &mut Self {
+        self.sequence = Some(sequence);
+        self
+    }
+
+    /// Builds the body of the tx with a given memo and timeout.
+    pub fn build_body<T: cosmrs::tx::Msg>(
+        msgs: Vec<T>,
+        memo: Option<&str>,
+        timeout: u64,
+    ) -> tx::Body {
+        let msgs = msgs
+            .into_iter()
+            .map(Msg::into_any)
+            .collect::<Result<Vec<Any>, _>>()
+            .unwrap();
+
+        tx::Body::new(msgs, memo.unwrap_or_default(), timeout as u32)
+    }
+
+    pub(crate) fn build_fee(amount: impl Into<u128>, denom: &str, gas_limit: Option<u64>) -> Fee {
+        let fee = Coin::new(amount.into(), denom).unwrap();
+        let gas = gas_limit.unwrap_or(GAS_LIMIT);
+        Fee::from_amount_and_gas(fee, gas)
+    }
+
+    /// Builds the raw tx with a given body and fee and signs it.
+    pub async fn build(&self, wallet: &Sender<All>) -> Result<Raw, DaemonError> {
+        // get the account number of the wallet
+        let BaseAccount {
+            account_number,
+            sequence,
+            ..
+        } = wallet.base_account().await?;
+
+        // overwrite sequence if set (can be used for concurrent txs)
+        let sequence = self.sequence.unwrap_or(sequence);
+
+        //
+        let tx_fee = if let Some(fee) = self.fee_amount {
+            fee
+        } else {
+            let sim_gas_used = wallet
+                .calculate_gas(&self.body, sequence, account_number)
+                .await?;
+            log::debug!("Simulated gas needed {:?}", sim_gas_used);
+
+            let gas_expected = sim_gas_used as f64 * GAS_BUFFER;
+            let fee_amount = gas_expected
+                * (wallet.daemon_state.chain_data.fees.fee_tokens[0].fixed_min_gas_price + 0.00001);
+
+            log::debug!("Calculated fee needed: {:?}", fee_amount);
+            fee_amount as u128
+        };
+
+        let fee = Self::build_fee(
+            tx_fee,
+            &wallet.daemon_state.chain_data.fees.fee_tokens[0].denom,
+            self.gas_limit,
+        );
+
+        let auth_info = SignerInfo::single_direct(Some(wallet.private_key.public_key()), sequence)
+            .auth_info(fee);
+
+        let sign_doc = SignDoc::new(
+            &self.body,
+            &auth_info,
+            &Id::try_from(wallet.daemon_state.chain_data.chain_id.to_string())?,
+            account_number,
+        )?;
+
+        sign_doc.sign(&wallet.private_key).map_err(Into::into)
+    }
+}

--- a/cw-orch/src/daemon/tx_builder.rs
+++ b/cw-orch/src/daemon/tx_builder.rs
@@ -9,7 +9,7 @@ use secp256k1::All;
 use super::{sender::Sender, DaemonError, Wallet};
 
 const GAS_BUFFER: f64 = 1.2;
-const GAS_LIMIT: u64 = 2_000_000;
+const GAS_LIMIT: u64 = 200_000_000;
 
 /// Struct used to build a raw transaction and broadcast it with a sender.
 pub struct TxBuilder {

--- a/cw-orch/tests/common/mod.rs
+++ b/cw-orch/tests/common/mod.rs
@@ -183,7 +183,9 @@ mod node {
 
     #[ctor]
     fn common_start() {
-        env_logger::init();
+        env_logger::Builder::new()
+            .filter_level(log::LevelFilter::Debug)
+            .init();
         docker_container_start()
     }
 

--- a/cw-orch/tests/daemon_helpers.rs
+++ b/cw-orch/tests/daemon_helpers.rs
@@ -89,6 +89,31 @@ mod tests {
             .is_ok();
     }
 
+    // #[test]
+    // #[serial_test::serial]
+    // fn wrong_min_fee() {
+    //     use cw_orch::prelude::networks;
+
+    //     let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    //     let mut chain = networks::UNI_6;
+    //     chain.gas_price = 0.00001;
+
+    //     let daemon = Daemon::builder()
+    //         .chain(chain)
+    //         .handle(runtime.handle())
+    //         .mnemonic("tide genuine angle mass fall promote blind skull swim army maximum add peasant fringe uncle october female crisp voyage blind extend jeans give wrap")
+    //         .build()
+    //         .unwrap();
+
+    //     let contract = mock_contract::MockContract::new(
+    //         format!("test:mock_contract:{}", Id::new()),
+    //         daemon.clone(),
+    //     );
+
+    //     contract.upload().unwrap();
+    // }
+
     #[test]
     #[serial_test::serial]
     fn cw_orch_interface_traits() {


### PR DESCRIPTION
Refactor the tx construction to be seperated from the sender object. This allows for more flexibly tx execution, which is applied in the case when the fee of a tx is not sufficient. In this case the returned log is parsed and the suggested fee is used.