### PR TITLE
[Fix] Remove QueryMsg variant doc attributes before function construction.

### DIFF
--- a/contracts/mock_contract/src/lib.rs
+++ b/contracts/mock_contract/src/lib.rs
@@ -14,9 +14,12 @@ pub enum ExecuteMsg<T = String> {
     FirstMessage {},
     #[cfg_attr(feature = "interface", payable)]
     SecondMessage {
+        /// test doc-comment
         t: T,
     },
+    /// test doc-comment
     ThirdMessage {
+        /// test doc-comment
         t: T,
     },
 }
@@ -26,9 +29,13 @@ pub enum ExecuteMsg<T = String> {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(String)]
+    /// test-doc-comment
     FirstQuery {},
     #[returns(String)]
-    SecondQuery { t: String },
+    SecondQuery {
+        /// test doc-comment
+        t: String,
+    },
 }
 
 #[cw_serde]

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -49,6 +49,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
 
                 // parse these fields as arguments to function
                 let mut variant_idents = variant_fields.named.clone();
+
                 // remove any attributes for use in fn arguments
                 variant_idents.iter_mut().for_each(|f| f.attrs = vec![]);
 

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -44,6 +44,9 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                 // sort fields on field name
                 LexiographicMatching::default().visit_fields_named_mut(variant_fields);
 
+                // remove attributes from fields
+                variant_fields.named.iter_mut().for_each(|f| f.attrs = vec![]);
+
                 // Parse these fields as arguments to function
                 let variant_fields = variant_fields.named.clone();
                 let variant_idents = variant_fields.iter().map(|f|f.ident.clone().unwrap());


### PR DESCRIPTION
Allows for doc-comments on the `QueryMsg` variant fields when using the `QueryFns` macro.  