### PR TITLE
Feat/Add balance function for Mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Add `add_balance` function on the `Mock` type. 
+
 ## v0.10.0
 
 - Update `CallAs` to be generic over environments.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-3.0-only"
 repository = "https://github.com/AbstractSDK/cw-orchestrator"
 
 [workspace.dependencies]
+cw-utils = { version = "1.0.1" }
 cosmwasm-std = { version = "1.1" }
 cw-multi-test = { version = "0.16.4" }
 anyhow = "1.0"

--- a/cw-orch/Cargo.toml
+++ b/cw-orch/Cargo.toml
@@ -68,6 +68,7 @@ cw-orch-contract-derive = { path = "../packages/cw-orch-contract-derive", versio
 cw-orch-fns-derive = { path = "../packages/cw-orch-fns-derive", version = "0.13.3" }
 
 cosmwasm-std = { workspace = true }
+cw-utils = { workspace = true }
 cw-multi-test = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
This PR aims to add a add_balance function for `Mock`
This allows adding Bank balance without overriding it with `set_balance`