### PR TITLE
Fix doc builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ impl<Chain: CwEnv> Example<Chain> {
 
 ### Testing with OsmosisTestTube
 
-[OsmosisTestTube](https://github.com/osmosis-labs/test-tube) is available for testing in cw-orchestrator. In order to use it, you may need to install [clang] and [go] to compile the osmosis blockchain that serves as the backend for this env. This compilation is taken care of by cargo directly but if you don't have the right dependencies installed, weird errors may arise. Visit https://docs.osmosis.zone/osmosis-core/osmosisd for a comprehensive list of dependencies.
+[OsmosisTestTube](https://github.com/osmosis-labs/test-tube) is available for testing in cw-orchestrator. In order to use it, you may need to install [clang](https://clang.llvm.org/) and [go](https://go.dev/) to compile the osmosis blockchain that serves as the backend for this env. This compilation is taken care of by cargo directly but if you don't have the right dependencies installed, weird errors may arise. Visit <https://docs.osmosis.zone/osmosis-core/osmosisd> for a comprehensive list of dependencies.
 
 ## Contributing
 

--- a/cw-orch/src/lib.rs
+++ b/cw-orch/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/AbstractSDK/assets/mainline/logo.svg")]
-#![doc = include_str ! ("../README.md")]
+#![doc = include_str ! (concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 #![deny(missing_docs)]
 
 // macros

--- a/packages/cw-orch-contract-derive/src/lib.rs
+++ b/packages/cw-orch-contract-derive/src/lib.rs
@@ -229,7 +229,7 @@ pub fn instantiate(
    env: Env,
    info: MessageInfo,
    msg: InstantiateMsg,
- -> StdResult<Response> {
+) -> StdResult<Response> {
     // ...
 }
 // ... other entry points (execute, query, migrate)


### PR DESCRIPTION
Fixed few warnings, but was unable to reproduce [the error](https://docs.rs/crate/cw-orch/0.13.3/builds/854107) with `cargo doc` or docs.rs [build subcommand](https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand)