### PR TITLE
Clarify supported chain docs

### DIFF
--- a/cw-orch/src/daemon/networks/archway.rs
+++ b/cw-orch/src/daemon/networks/archway.rs
@@ -1,27 +1,12 @@
 use crate::daemon::networks::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: archway
 pub const ARCHWAY_NETWORK: NetworkInfo = NetworkInfo {
     id: "archway",
     pub_address_prefix: "archway",
     coin_type: 118u32,
 };
 
-#[deprecated(
-    since = "0.6.1",
-    note = "Constantine-1 does not exist anymore. Use Constantine-3 instead."
-)]
-pub const CONSTANTINE_1: ChainInfo = ChainInfo {
-    kind: ChainKind::Testnet,
-    chain_id: "constantine-1",
-    gas_denom: "uconst",
-    gas_price: 0.025,
-    grpc_urls: &["https://grpc.constantine-1.archway.tech:443"],
-    network_info: ARCHWAY_NETWORK,
-    lcd_url: Some("https://api.constantine-1.archway.tech"),
-    fcd_url: None,
-};
-
-// ANCHOR: archway
 /// Archway Docs: <https://docs.archway.io/resources/networks>
 /// Parameters: <https://testnet.mintscan.io/archway-testnet/parameters>
 pub const CONSTANTINE_3: ChainInfo = ChainInfo {
@@ -48,3 +33,18 @@ pub const ARCHWAY_1: ChainInfo = ChainInfo {
     fcd_url: None,
 };
 // ANCHOR_END: archway
+
+#[deprecated(
+since = "0.6.1",
+note = "Constantine-1 does not exist anymore. Use Constantine-3 instead."
+)]
+pub const CONSTANTINE_1: ChainInfo = ChainInfo {
+    kind: ChainKind::Testnet,
+    chain_id: "constantine-1",
+    gas_denom: "uconst",
+    gas_price: 0.025,
+    grpc_urls: &["https://grpc.constantine-1.archway.tech:443"],
+    network_info: ARCHWAY_NETWORK,
+    lcd_url: Some("https://api.constantine-1.archway.tech"),
+    fcd_url: None,
+};

--- a/cw-orch/src/daemon/networks/archway.rs
+++ b/cw-orch/src/daemon/networks/archway.rs
@@ -35,8 +35,8 @@ pub const ARCHWAY_1: ChainInfo = ChainInfo {
 // ANCHOR_END: archway
 
 #[deprecated(
-since = "0.6.1",
-note = "Constantine-1 does not exist anymore. Use Constantine-3 instead."
+    since = "0.6.1",
+    note = "Constantine-1 does not exist anymore. Use Constantine-3 instead."
 )]
 pub const CONSTANTINE_1: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,

--- a/cw-orch/src/daemon/networks/injective.rs
+++ b/cw-orch/src/daemon/networks/injective.rs
@@ -1,11 +1,11 @@
 use crate::daemon::networks::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: injective
 pub const INJECTIVE_NETWORK: NetworkInfo = NetworkInfo {
     id: "injective",
     pub_address_prefix: "inj",
     coin_type: 60u32,
 };
-// ANCHOR: injective
 
 /// <https://docs.injective.network/develop/public-endpoints/#mainnet>
 /// <https://www.mintscan.io/injective/parameters>
@@ -33,5 +33,4 @@ pub const INJECTIVE_888: ChainInfo = ChainInfo {
     lcd_url: None,
     fcd_url: None,
 };
-
 // ANCHOR_END: injective

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -46,10 +46,9 @@ pub const LOCAL_JUNO: ChainInfo = ChainInfo {
 };
 // ANCHOR_END: juno
 
-
 #[deprecated(
-since = "0.6.1",
-note = "Uni-5 does not exist anymore. Use Uni-6 instead."
+    since = "0.6.1",
+    note = "Uni-5 does not exist anymore. Use Uni-6 instead."
 )]
 pub const UNI_5: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,

--- a/cw-orch/src/daemon/networks/juno.rs
+++ b/cw-orch/src/daemon/networks/juno.rs
@@ -2,28 +2,13 @@ use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
 // https://notional.ventures/resources/endpoints#juno
 
+// ANCHOR: juno
 pub const JUNO_NETWORK: NetworkInfo = NetworkInfo {
     id: "juno",
     pub_address_prefix: "juno",
     coin_type: 118u32,
 };
 
-#[deprecated(
-    since = "0.6.1",
-    note = "Uni-5 does not exist anymore. Use Uni-6 instead."
-)]
-pub const UNI_5: ChainInfo = ChainInfo {
-    kind: ChainKind::Testnet,
-    chain_id: "uni-5",
-    gas_denom: "ujunox",
-    gas_price: 0.025,
-    grpc_urls: &["https://juno-testnet-grpc.polkachu.com:12690"],
-    network_info: JUNO_NETWORK,
-    lcd_url: None,
-    fcd_url: None,
-};
-
-// ANCHOR: juno
 pub const UNI_6: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
     chain_id: "uni-6",
@@ -60,3 +45,19 @@ pub const LOCAL_JUNO: ChainInfo = ChainInfo {
     fcd_url: None,
 };
 // ANCHOR_END: juno
+
+
+#[deprecated(
+since = "0.6.1",
+note = "Uni-5 does not exist anymore. Use Uni-6 instead."
+)]
+pub const UNI_5: ChainInfo = ChainInfo {
+    kind: ChainKind::Testnet,
+    chain_id: "uni-5",
+    gas_denom: "ujunox",
+    gas_price: 0.025,
+    grpc_urls: &["https://juno-testnet-grpc.polkachu.com:12690"],
+    network_info: JUNO_NETWORK,
+    lcd_url: None,
+    fcd_url: None,
+};

--- a/cw-orch/src/daemon/networks/kujira.rs
+++ b/cw-orch/src/daemon/networks/kujira.rs
@@ -1,12 +1,11 @@
 use crate::daemon::networks::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: kujira
 pub const KUJIRA_NETWORK: NetworkInfo = NetworkInfo {
     id: "kujira",
     pub_address_prefix: "kujira",
     coin_type: 118u32,
 };
-
-// ANCHOR: kujira
 
 pub const HARPOON_4: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
@@ -18,5 +17,4 @@ pub const HARPOON_4: ChainInfo = ChainInfo {
     lcd_url: None,
     fcd_url: None,
 };
-
 // ANCHOR_END: kujira

--- a/cw-orch/src/daemon/networks/neutron.rs
+++ b/cw-orch/src/daemon/networks/neutron.rs
@@ -1,12 +1,12 @@
 use crate::daemon::networks::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: neutron
 pub const NEUTRON_NETWORK: NetworkInfo = NetworkInfo {
     id: "neutron",
     pub_address_prefix: "neutron",
     coin_type: 118u32,
 };
 
-// ANCHOR: neutron
 /// <https://github.com/cosmos/chain-registry/blob/master/testnets/neutrontestnet/chain.json>
 pub const PION_1: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
@@ -41,5 +41,4 @@ pub const LOCAL_NEUTRON: ChainInfo = ChainInfo {
     lcd_url: None,
     fcd_url: None,
 };
-
 // ANCHOR_END: neutron

--- a/cw-orch/src/daemon/networks/osmosis.rs
+++ b/cw-orch/src/daemon/networks/osmosis.rs
@@ -1,12 +1,11 @@
 use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: osmosis
 pub const OSMO_NETWORK: NetworkInfo = NetworkInfo {
     id: "osmosis",
     pub_address_prefix: "osmo",
     coin_type: 118u32,
 };
-
-// ANCHOR: osmosis
 
 pub const OSMO_5: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
@@ -29,5 +28,4 @@ pub const LOCAL_OSMO: ChainInfo = ChainInfo {
     lcd_url: None,
     fcd_url: None,
 };
-
 // ANCHOR_END: osmosis

--- a/cw-orch/src/daemon/networks/sei.rs
+++ b/cw-orch/src/daemon/networks/sei.rs
@@ -1,12 +1,11 @@
 use crate::daemon::networks::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: sei
 pub const SEI_NETWORK: NetworkInfo = NetworkInfo {
     id: "sei",
     pub_address_prefix: "sei",
     coin_type: 118u32,
 };
-
-// ANCHOR: sei
 
 pub const LOCAL_SEI: ChainInfo = ChainInfo {
     kind: ChainKind::Local,

--- a/cw-orch/src/daemon/networks/terra.rs
+++ b/cw-orch/src/daemon/networks/terra.rs
@@ -1,12 +1,12 @@
 use crate::daemon::chain_info::{ChainInfo, ChainKind, NetworkInfo};
 
+// ANCHOR: terra
 pub const TERRA_NETWORK: NetworkInfo = NetworkInfo {
     id: "terra2",
     pub_address_prefix: "terra",
     coin_type: 330u32,
 };
 
-// ANCHOR: terra
 /// Terra testnet network.
 /// <https://docs.terra.money/develop/endpoints>
 pub const PISCO_1: ChainInfo = ChainInfo {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,7 +26,7 @@
 
 [//]: # (- [live-chains]&#40;&#41;)
 
-- [Supported Chains]()
+- [Supported Chains](./chains/index.md)
   - [Archway](./chains/archway.md)
   - [Injective](./chains/injective.md)
   - [Juno](./chains/juno.md)
@@ -35,7 +35,6 @@
   - [Osmosis](./chains/osmosis.md)
   - [Sei](./chains/sei.md)
   - [Terra](./chains/terra.md)
-  - [Other](./chains/other.md)
 
 # Extras
 

--- a/docs/src/chains/archway.md
+++ b/docs/src/chains/archway.md
@@ -5,8 +5,6 @@ Archway is a smart contract platform that directly rewards developers for their 
 [Archway Website](https://archway.io/)
 
 ## Usage
-
-
 See how to setup your main function in the [main function](../single_contract/scripting.md#main-function) section. Update the network passed into the `Daemon` builder to be `networks::ARCHWAY_1`.
 
 ```rust,ignore

--- a/docs/src/chains/index.md
+++ b/docs/src/chains/index.md
@@ -1,0 +1,10 @@
+# Supported Chains
+
+Cw-Orchestrator currently has support for the chains in the following subsections.
+
+## Support a new CosmWasm Chain
+If you would like to add support for another chain, please feel free to [open a PR](https://github.com/AbstractSDK/cw-orchestrator/compare)!
+
+
+## Issues
+Each of the gRPC endpoints has been battle-tested for deployments. If you find any issues, please [open an issue](https://github.com/AbstractSDK/cw-orchestrator/issues/new)!

--- a/docs/src/chains/osmosis.md
+++ b/docs/src/chains/osmosis.md
@@ -6,7 +6,7 @@ Osmosis is a cutting-edge decentralized exchange built on the Cosmos network, de
 
 ## Usage
 
-See how to setup your main function in the [main function](../single_contract/scripting.md#main-function) section. Update the network passed into the `Daemon` builder to be `networks::OSMOSIS_1`.
+See how to setup your main function in the [main function](../single_contract/scripting.md#main-function) section. Update the network passed into the `Daemon` builder to be `networks::OSMO_5`.
 
 ```rust,ignore
 {{#include ../../../cw-orch/src/daemon/networks/osmosis.rs:osmosis}}


### PR DESCRIPTION
This change clarifies support of the cw-orchestrator chains.

It also moves the deprecated networks beyond the anchor.