### PR TITLE
Fix the ExecuteMsgFns macro in case there is a where clause

### DIFF
--- a/contracts/mock_contract/Cargo.toml
+++ b/contracts/mock_contract/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1.0.79"
 thiserror = { version = "1.0.21" }
 cosmwasm-schema = "1.2"
 cw-orch = { path = "../../cw-orch", optional = true }
+
+[dev-dependencies]
+mock-contract = { path = ".", features = ["interface"] }

--- a/cw-orch/Cargo.toml
+++ b/cw-orch/Cargo.toml
@@ -60,7 +60,7 @@ daemon = [
   "dep:prost",
 ]
 eth = ["daemon", "dep:ethers-signers", "dep:ethers-core", "dep:snailquote"]
-osmosis-test-tube = ["dep:osmosis-test-tube"]
+osmosis-test-tube = ["dep:osmosis-test-tube", "dep:osmosis-std"]
 
 [dependencies]
 # Default deps
@@ -115,7 +115,8 @@ ethers-core = { version = "2.0.7", optional = true }
 snailquote = { version = "0.3.1", optional = true }
 
 # Test Tube env deps
-osmosis-test-tube = { version = "16.0.0", optional = true }
+osmosis-test-tube = { version = "=17.0.0-rc0", optional = true }
+osmosis-std = { version = "=0.17.0-rc0", optional = true }
 
 [dev-dependencies]
 cw-orch = { features = ["daemon"], path = "." }

--- a/cw-orch/src/osmosis_test_tube/core.rs
+++ b/cw-orch/src/osmosis_test_tube/core.rs
@@ -9,8 +9,6 @@ use cosmwasm_std::Coin;
 use cosmwasm_std::Timestamp;
 use cosmwasm_std::Uint128;
 use cw_multi_test::AppResponse;
-use osmosis_test_tube::osmosis_std::cosmwasm_to_proto_coins;
-use osmosis_test_tube::osmosis_std::types::cosmos::bank::v1beta1::MsgSend;
 use osmosis_test_tube::Account;
 use osmosis_test_tube::Bank;
 use osmosis_test_tube::Gamm;
@@ -19,9 +17,21 @@ use osmosis_test_tube::SigningAccount;
 use osmosis_test_tube::Wasm;
 use std::str::FromStr;
 
-use osmosis_test_tube::osmosis_std::types::cosmos::bank::v1beta1::{
-    QueryAllBalancesRequest, QueryBalanceRequest,
+// This should be the way to import stuff.
+// But apparently osmosis-test-tube doesn't have the same dependencies as the test-tube package
+// use osmosis_test_tube::osmosis_std::{
+//     types::cosmos::bank::v1beta1::{
+//         QueryAllBalancesRequest, QueryBalanceRequest, MsgSend
+//     },
+//     cosmwasm_to_proto_coins
+// };
+
+// So we need this fix (not ideal)
+use osmosis_std::{
+    cosmwasm_to_proto_coins,
+    types::cosmos::bank::v1beta1::{MsgSend, QueryAllBalancesRequest, QueryBalanceRequest},
 };
+
 use osmosis_test_tube::OsmosisTestApp;
 use std::{cell::RefCell, fmt::Debug, rc::Rc};
 

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -15,8 +15,6 @@ fn payable(v: &syn::Variant) -> bool {
 }
 
 pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
-
-
     let name = &input.ident;
     let bname = Ident::new(&format!("{name}Fns"), name.span());
 
@@ -85,16 +83,16 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
     // We need to merge the where clauses (rust doesn't support 2 wheres)
     // If there is no where clause, we simply add the necessary where
     let necessary_where = quote!(SupportedContract: ::cw_orch::prelude::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics >);
-    let combined_where_clause = where_clause.map(|w|
-        quote!(
-            #w #necessary_where
-        )
-    ).unwrap_or(
-        quote!(
+    let combined_where_clause = where_clause
+        .map(|w| {
+            quote!(
+                #w #necessary_where
+            )
+        })
+        .unwrap_or(quote!(
             where
                 #necessary_where
-        )
-    );
+        ));
 
     let derived_trait_impl = quote!(
         #[automatically_derived]

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -64,8 +64,8 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                 }
             }
         }
-    );    
-    
+    );
+
     let derived_trait = quote!(
         pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics > #where_clause {
             #(#variant_fns)*
@@ -75,16 +75,16 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
     // We need to merge the where clauses (rust doesn't support 2 wheres)
     // If there is no where clause, we simply add the necessary where
     let necessary_where = quote!(SupportedContract: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics >);
-    let combined_where_clause = where_clause.map(|w|
-        quote!(
-            #w #necessary_where
-        )
-    ).unwrap_or(
-        quote!(
+    let combined_where_clause = where_clause
+        .map(|w| {
+            quote!(
+                #w #necessary_where
+            )
+        })
+        .unwrap_or(quote!(
             where
                 #necessary_where
-        )
-    );
+        ));
 
     let derived_trait_impl = quote!(
         impl<SupportedContract, Chain: ::cw_orch::prelude::CwEnv, #type_generics> #bname<Chain, #type_generics> for SupportedContract

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -64,18 +64,31 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                 }
             }
         }
-    );
-
+    );    
+    
     let derived_trait = quote!(
-        pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics #where_clause> {
+        pub trait #bname<Chain: ::cw_orch::prelude::CwEnv, #type_generics>: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics > #where_clause {
             #(#variant_fns)*
         }
     );
 
+    // We need to merge the where clauses (rust doesn't support 2 wheres)
+    // If there is no where clause, we simply add the necessary where
+    let necessary_where = quote!(SupportedContract: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics >);
+    let combined_where_clause = where_clause.map(|w|
+        quote!(
+            #w #necessary_where
+        )
+    ).unwrap_or(
+        quote!(
+            where
+                #necessary_where
+        )
+    );
+
     let derived_trait_impl = quote!(
         impl<SupportedContract, Chain: ::cw_orch::prelude::CwEnv, #type_generics> #bname<Chain, #type_generics> for SupportedContract
-        where
-            SupportedContract: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics #where_clause>{}
+        #combined_where_clause {}
     );
 
     let expand = quote!(


### PR DESCRIPTION
This PR aims at fixing the macro when you are creating the ExecuteMsgFns macro along with a generic type and a where clause