### PR TITLE
Added Unit variant to execute and query fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unpublished
 
+- Ability to use the ExecuteFns and QueryFns traits on Units and Unnamed enum variants by @Kayanski
+
+
+## v0.15.0
+
 - Add `add_balance` function on the `Mock` type. 
 
 ## v0.10.0

--- a/contracts/mock_contract/src/lib.rs
+++ b/contracts/mock_contract/src/lib.rs
@@ -127,6 +127,7 @@ mod test {
         // We need to check we can still call the execute msgs conveniently
         let sender = Addr::unchecked("sender");
         let mock = Mock::new(&sender);
+        mock.set_balance(&sender, coins(156, "ujuno"))?;
         let contract = LocalMockContract::new("mock-contract", mock.clone());
 
         contract.upload()?;

--- a/contracts/mock_contract/src/lib.rs
+++ b/contracts/mock_contract/src/lib.rs
@@ -26,6 +26,7 @@ where
         /// test doc-comment
         t: T,
     },
+    FourthMessage,
 }
 
 #[cw_serde]
@@ -43,6 +44,8 @@ where
         /// test doc-comment
         t: T,
     },
+    #[returns(String)]
+    ThirdQuery,
 }
 
 #[cw_serde]
@@ -77,6 +80,9 @@ pub fn execute(
         ExecuteMsg::ThirdMessage { .. } => {
             Ok(Response::new().add_attribute("action", "third message passed"))
         }
+        ExecuteMsg::FourthMessage => {
+            Ok(Response::new().add_attribute("action", "fourth message passed"))
+        }
     }
 }
 
@@ -86,6 +92,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::FirstQuery {} => to_binary("first query passed"),
         QueryMsg::SecondQuery { .. } => Err(StdError::generic_err("Query not available")),
+        QueryMsg::ThirdQuery {} => to_binary("third query passed"),
     }
 }
 
@@ -117,6 +124,7 @@ mod test {
         contract.instantiate(&InstantiateMsg {}, None, None)?;
         contract.first_message()?;
         contract.second_message("s".to_string(), &[]).unwrap_err();
+        contract.fourth_message().unwrap();
 
         Ok(())
     }

--- a/contracts/mock_contract_u64/src/lib.rs
+++ b/contracts/mock_contract_u64/src/lib.rs
@@ -31,6 +31,9 @@ pub fn execute(
         ExecuteMsg::ThirdMessage { .. } => {
             Ok(Response::new().add_attribute("action", "third message passed"))
         }
+        ExecuteMsg::FourthMessage => {
+            Ok(Response::new().add_attribute("action", "fourth message passed"))
+        }
     }
 }
 
@@ -40,6 +43,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::FirstQuery {} => to_binary("first query passed"),
         QueryMsg::SecondQuery { .. } => Err(StdError::generic_err("Query not available")),
+        QueryMsg::ThirdQuery {} => to_binary("third query passed"),
     }
 }
 

--- a/contracts/mock_contract_u64/src/lib.rs
+++ b/contracts/mock_contract_u64/src/lib.rs
@@ -20,7 +20,7 @@ pub fn instantiate(
 pub fn execute(
     _deps: DepsMut,
     _env: Env,
-    _info: MessageInfo,
+    info: MessageInfo,
     msg: ExecuteMsg<u64>,
 ) -> StdResult<Response> {
     match msg {
@@ -34,6 +34,12 @@ pub fn execute(
         ExecuteMsg::FourthMessage => {
             Ok(Response::new().add_attribute("action", "fourth message passed"))
         }
+        ExecuteMsg::FifthMessage => {
+            if info.funds.is_empty() {
+                return Err(StdError::generic_err("Coins missing"));
+            }
+            Ok(Response::new().add_attribute("action", "fourth message passed"))
+        }
     }
 }
 
@@ -43,7 +49,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::FirstQuery {} => to_binary("first query passed"),
         QueryMsg::SecondQuery { .. } => Err(StdError::generic_err("Query not available")),
-        QueryMsg::ThirdQuery {} => to_binary("third query passed"),
+        QueryMsg::ThirdQuery => to_binary("third query passed"),
     }
 }
 

--- a/contracts/mock_contract_u64/src/lib.rs
+++ b/contracts/mock_contract_u64/src/lib.rs
@@ -40,6 +40,16 @@ pub fn execute(
             }
             Ok(Response::new().add_attribute("action", "fourth message passed"))
         }
+        ExecuteMsg::SixthMessage(_, _) => {
+            Ok(Response::new().add_attribute("action", "sixth message passed"))
+        }
+        ExecuteMsg::SeventhMessage(amount, denom) => {
+            let c = info.funds[0].clone();
+            if c.amount != amount && c.denom.ne(&denom) {
+                return Err(StdError::generic_err("Coins don't match message"));
+            }
+            Ok(Response::new().add_attribute("action", "fourth message passed"))
+        }
     }
 }
 
@@ -50,6 +60,7 @@ pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::FirstQuery {} => to_binary("first query passed"),
         QueryMsg::SecondQuery { .. } => Err(StdError::generic_err("Query not available")),
         QueryMsg::ThirdQuery => to_binary("third query passed"),
+        QueryMsg::FourthQuery(_, _) => to_binary("fourth query passed"),
     }
 }
 

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -50,7 +50,6 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
                     (quote!(),quote!(None))
                 };
                 Some(quote!(
-                    #[allow(clippy::too_many_arguments)]
                     fn #variant_func_name(&self, #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
                         let msg = #name::#variant_name;
                         <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 use crate::helpers::{process_fn_name, process_impl_into, LexiographicMatching};
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{visit_mut::VisitMut, DeriveInput, Fields, Ident};
 
@@ -31,7 +32,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
         unimplemented!();
     };
 
-    let variant_fns = variants.into_iter().filter_map( |mut variant|{
+    let variant_fns = variants.into_iter().map( |mut variant|{
         let variant_name = variant.ident.clone();
 
         // We rename the variant if it has a fn_name attribute associated with it
@@ -48,15 +49,46 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
         };
 
         match &mut variant.fields {
-            Fields::Unnamed(_) => None,
+            Fields::Unnamed(variant_fields) => {
+                // This is dangerous because of field ordering. Though, if people use like that, they know what to expect anyway
+
+                let mut variant_idents = variant_fields.unnamed.clone();
+                // remove any attributes for use in fn arguments
+                variant_idents.iter_mut().for_each(|f: &mut syn::Field| f.attrs = vec![]);
+
+
+                // We need to figure out a parameter name for all fields associated to their types
+                // They will be numbered from 0 to n-1
+                let variant_ident_content_names = variant_idents
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)|  Ident::new(&format!("arg{}", i), Span::call_site()));
+
+                let variant_attr = variant_idents.clone().into_iter()
+                    .enumerate()
+                    .map(|(i, mut id)| {
+                    id.ident = Some(Ident::new(&format!("arg{}", i), Span::call_site()));
+                    id
+                });
+
+                quote!(
+                    #[allow(clippy::too_many_arguments)]
+                    fn #variant_func_name(&self, #(#variant_attr,)* #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
+                        let msg = #name::#variant_name (
+                            #(#variant_ident_content_names,)*
+                        );
+                        <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
+                    }
+                )
+            },
             Fields::Unit => {
 
-                Some(quote!(
+                quote!(
                     fn #variant_func_name(&self, #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
                         let msg = #name::#variant_name;
                         <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
                     }
-                ))
+                )
             }
             Fields::Named(variant_fields) => {
                 // sort fields on field name
@@ -66,12 +98,12 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
                 let mut variant_idents = variant_fields.named.clone();
 
                 // remove any attributes for use in fn arguments
-                variant_idents.iter_mut().for_each(|f| f.attrs = vec![]);
+                variant_idents.iter_mut().for_each(|f: &mut syn::Field| f.attrs = vec![]);
 
                 let variant_ident_content_names = variant_idents.iter().map(|f|f.ident.clone().unwrap());
 
                 let variant_attr = variant_idents.iter();
-                Some(quote!(
+                quote!(
                     #[allow(clippy::too_many_arguments)]
                     fn #variant_func_name(&self, #(#variant_attr,)* #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
                         let msg = #name::#variant_name {
@@ -79,7 +111,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
                         };
                         <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
                     }
-                ))
+                )
             }
         }
     });

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -40,15 +40,17 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
         variant_func_name.set_span(variant_name.span());
 
         let is_payable = payable(&variant);
+
+        let (maybe_coins_attr, passed_coins) = if is_payable {
+            (quote!(coins: &[::cosmwasm_std::Coin]),quote!(Some(coins)))
+        } else {
+            (quote!(),quote!(None))
+        };
+
         match &mut variant.fields {
             Fields::Unnamed(_) => None,
             Fields::Unit => {
 
-                let (maybe_coins_attr, passed_coins) = if is_payable {
-                    (quote!(coins: &[::cosmwasm_std::Coin]),quote!(Some(coins)))
-                } else {
-                    (quote!(),quote!(None))
-                };
                 Some(quote!(
                     fn #variant_func_name(&self, #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
                         let msg = #name::#variant_name;
@@ -68,11 +70,6 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
 
                 let variant_ident_content_names = variant_idents.iter().map(|f|f.ident.clone().unwrap());
 
-                let (maybe_coins_attr, passed_coins) = if is_payable {
-                    (quote!(coins: &[::cosmwasm_std::Coin]),quote!(Some(coins)))
-                } else {
-                    (quote!(),quote!(None))
-                };
                 let variant_attr = variant_idents.iter();
                 Some(quote!(
                     #[allow(clippy::too_many_arguments)]

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -42,7 +42,21 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
         let is_payable = payable(&variant);
         match &mut variant.fields {
             Fields::Unnamed(_) => None,
-            Fields::Unit => None,
+            Fields::Unit => {
+
+                let (maybe_coins_attr, passed_coins) = if is_payable {
+                    (quote!(coins: &[::cosmwasm_std::Coin]),quote!(Some(coins)))
+                } else {
+                    (quote!(),quote!(None))
+                };
+                Some(quote!(
+                    #[allow(clippy::too_many_arguments)]
+                    fn #variant_func_name(&self, #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
+                        let msg = #name::#variant_name;
+                        <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
+                    }
+                ))
+            }
             Fields::Named(variant_fields) => {
                 // sort fields on field name
                 LexiographicMatching::default().visit_fields_named_mut(variant_fields);

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -133,7 +133,5 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
         #derived_trait_impl
     );
 
-    // panic!("{}", expand);
-
     expand.into()
 }

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -41,7 +41,6 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
             Fields::Unnamed(_) => panic!("Expected named variant"),
             Fields::Unit => {
                 quote!(
-                    #[allow(clippy::too_many_arguments)]
                     fn #variant_func_name(&self) -> ::core::result::Result<#response, ::cw_orch::prelude::CwOrchError> {
                         let msg = #name::#variant_name;
                         self.query(&msg #maybe_into)


### PR DESCRIPTION
This PR aims at allowing projects to use unit variants in the ExecuteMsg and QueryMsg and still be able to use ExecuteFns and QueryFns.
An example usage is using cw-orch with Polytone : https://github.com/DA0-DA0/polytone/blob/a94feae54ee20cb51d8533d79229296e52164859/contracts/main/note/src/msg.rs#L59