### PR TITLE
Made the broadcast function public for advanced devs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unpublished
 
 - Ability to use the ExecuteFns and QueryFns traits on Units and Unnamed enum variants by @Kayanski
-
+- Make the broadcast function public on Sender
 
 ## v0.15.0
 

--- a/cw-orch-daemon/src/sender.rs
+++ b/cw-orch-daemon/src/sender.rs
@@ -242,7 +242,7 @@ impl Sender<All> {
         Ok(acc)
     }
 
-    async fn broadcast_tx(
+    pub async fn broadcast_tx(
         &self,
         tx: Raw,
     ) -> Result<cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse, DaemonError> {


### PR DESCRIPTION
This PR allows the broadcast function to be public. This allows advanced users to broadcast their txs manually