### PR TITLE
Make broadcast function public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unpublished
 
 - Ability to use the ExecuteFns and QueryFns traits on Units and Unnamed enum variants by @Kayanski
-
+- Broadcast function on the sender is public by @Kayanski
 
 ## v0.15.0
 

--- a/cw-orch-daemon/src/sender.rs
+++ b/cw-orch-daemon/src/sender.rs
@@ -242,7 +242,7 @@ impl Sender<All> {
         Ok(acc)
     }
 
-    async fn broadcast_tx(
+    pub async fn broadcast_tx(
         &self,
         tx: Raw,
     ) -> Result<cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse, DaemonError> {

--- a/cw-orch-daemon/src/sender.rs
+++ b/cw-orch-daemon/src/sender.rs
@@ -170,9 +170,7 @@ impl Sender<All> {
             let suggested_fee = parse_suggested_fee(&tx_response.raw_log);
 
             let Some(new_fee) = suggested_fee else {
-                return Err(DaemonError::InsufficientFee(
-                    tx_response.raw_log,
-                ));
+                return Err(DaemonError::InsufficientFee(tx_response.raw_log));
             };
 
             // update the fee and try again

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -24,11 +24,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
     let (maybe_into, entrypoint_msg_type, type_generics) =
         process_impl_into(&input.attrs, name, input.generics);
 
-    let syn::Data::Enum(syn::DataEnum {
-        variants,
-        ..
-    }) = input.data
-     else {
+    let syn::Data::Enum(syn::DataEnum { variants, .. }) = input.data else {
         unimplemented!();
     };
 


### PR DESCRIPTION
This PR aims at making the boadcast function of the sender public for using it if necessary by the users. This is not critical nor needed by any projects we work with, just thought it could be helpful