### PR TITLE
Changed lifetime for chain info in parse network

### DIFF
--- a/packages/cw-orch-networks/src/networks/mod.rs
+++ b/packages/cw-orch-networks/src/networks/mod.rs
@@ -32,14 +32,14 @@ pub use terra::{LOCAL_TERRA, PHOENIX_1, PISCO_1};
 /// ```
 /// ---
 /// supported chains are: UNI_6, JUNO_1, LOCAL_JUNO, PISCO_1, PHOENIX_1, LOCAL_TERRA, INJECTIVE_888, CONSTANTINE_1, BARYON_1, INJECTIVE_1, HARPOON_4, OSMO_4, LOCAL_OSMO
-pub fn parse_network(net_id: &str) -> ChainInfo {
+pub fn parse_network(net_id: &str) -> ChainInfo<'static> {
     match parse_network_safe(net_id) {
         Ok(net) => net,
         Err(err) => panic!("{}", err),
     }
 }
 
-pub fn parse_network_safe(net_id: &str) -> Result<ChainInfo, String> {
+pub fn parse_network_safe(net_id: &str) -> Result<ChainInfo<'static>, String> {
     let networks = vec![
         UNI_6,
         JUNO_1,


### PR DESCRIPTION
This PR fixes the parse network lifetime elision for crate defined consts.
This avoids such error messages : 
```
Compiling cw-orch-networks v0.16.0
error[E0106]: missing lifetime specifier
  --> /Users/robin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cw-orch-networks-0.16.0/src/networks/mod.rs:35:47
   |
35 | pub fn parse_network(net_id: Into<String>) -> ChainInfo {
   |                                               ^^^^^^^^^ expected named lifetime parameter
   |
   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
help: consider using the `'static` lifetime
   |
35 | pub fn parse_network(net_id: Into<String>) -> ChainInfo<'static> {
   |                                                        +++++++++

For more information about this error, try `rustc --explain E0106`.
error: could not compile `cw-orch-networks` (lib) due to previous error
error: failed to verify package tarball

```