### PR TITLE
Better Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added possibility to not panic in parse network by @Buckram123
 - Added stargate feature to cw-multi-test
+- Added message to enable logging if not enabled
 
 ## v0.16.4 [20th September 2023]
 

--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{log::print_if_disabled_log, DaemonAsync, DaemonBuilder};
+use crate::{log::print_if_log_disabled, DaemonAsync, DaemonBuilder};
 use std::rc::Rc;
 
 use ibc_chain_registry::chain::ChainData;
@@ -74,7 +74,7 @@ impl DaemonAsyncBuilder {
             state,
             sender: Rc::new(sender),
         };
-        print_if_disabled_log();
+        print_if_log_disabled();
         Ok(daemon)
     }
 }

--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{DaemonAsync, DaemonBuilder};
+use crate::{DaemonAsync, DaemonBuilder, log::print_if_disabled_log};
 use std::rc::Rc;
 
 use ibc_chain_registry::chain::ChainData;
@@ -74,6 +74,7 @@ impl DaemonAsyncBuilder {
             state,
             sender: Rc::new(sender),
         };
+        print_if_disabled_log();
         Ok(daemon)
     }
 }

--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{DaemonAsync, DaemonBuilder, log::print_if_disabled_log};
+use crate::{log::print_if_disabled_log, DaemonAsync, DaemonBuilder};
 use std::rc::Rc;
 
 use ibc_chain_registry::chain::ChainData;

--- a/cw-orch-daemon/src/channel.rs
+++ b/cw-orch-daemon/src/channel.rs
@@ -17,7 +17,7 @@ impl GrpcChannel {
         let mut successful_connections = vec![];
 
         for Grpc { address, .. } in grpc.iter() {
-            log::info!(target: CONNECTIVITY_LOGS, "Trying to connect to endpoint: {}", address);
+            log::debug!(target: CONNECTIVITY_LOGS, "Trying to connect to endpoint: {}", address);
 
             // get grpc endpoint
             let endpoint = Channel::builder(address.clone().try_into().unwrap());
@@ -41,7 +41,7 @@ impl GrpcChannel {
                     continue;
                 };
 
-                log::info!(target: CONNECTIVITY_LOGS, "Attempting to connect with TLS");
+                log::debug!(target: CONNECTIVITY_LOGS, "Attempting to connect with TLS");
 
                 // re attempt to connect
                 let endpoint = endpoint.clone().tls_config(ClientTlsConfig::new())?;

--- a/cw-orch-daemon/src/channel.rs
+++ b/cw-orch-daemon/src/channel.rs
@@ -1,6 +1,7 @@
 use cosmrs::proto::cosmos::base::tendermint::v1beta1::{
     service_client::ServiceClient, GetNodeInfoRequest,
 };
+use cw_orch_core::log::CONNECTIVITY_LOGS;
 use ibc_chain_registry::chain::Grpc;
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 use tonic::transport::{Channel, ClientTlsConfig};
@@ -16,7 +17,7 @@ impl GrpcChannel {
         let mut successful_connections = vec![];
 
         for Grpc { address, .. } in grpc.iter() {
-            log::info!("Trying to connect to endpoint: {}", address);
+            log::info!(target: CONNECTIVITY_LOGS, "Trying to connect to endpoint: {}", address);
 
             // get grpc endpoint
             let endpoint = Channel::builder(address.clone().try_into().unwrap());
@@ -40,7 +41,7 @@ impl GrpcChannel {
                     continue;
                 };
 
-                log::info!("Attempting to connect with TLS");
+                log::info!(target: CONNECTIVITY_LOGS, "Attempting to connect with TLS");
 
                 // re attempt to connect
                 let endpoint = endpoint.clone().tls_config(ClientTlsConfig::new())?;

--- a/cw-orch-daemon/src/core.rs
+++ b/cw-orch-daemon/src/core.rs
@@ -18,6 +18,7 @@ use cosmwasm_std::{Addr, Coin};
 use cw_orch_core::{
     contract::interface_traits::Uploadable,
     environment::{ChainState, IndexResponse},
+    log::TRANSACTION_LOGS,
 };
 use flate2::{write, Compression};
 use serde::{de::DeserializeOwned, Serialize};
@@ -111,6 +112,8 @@ impl DaemonAsync {
             funds: parse_cw_coins(coins)?,
         };
         let result = self.sender.commit_tx(vec![exec_msg], None).await?;
+        log::info!(target: TRANSACTION_LOGS, "Execution done: {:?}", result.txhash);
+
         Ok(result)
     }
 
@@ -135,6 +138,8 @@ impl DaemonAsync {
         };
 
         let result = sender.commit_tx(vec![init_msg], None).await?;
+
+        log::info!(target: TRANSACTION_LOGS, "Instantiation done: {:?}", result.txhash);
 
         Ok(result)
     }
@@ -231,7 +236,7 @@ impl DaemonAsync {
         let sender = &self.sender;
         let wasm_path = uploadable.wasm();
 
-        log::debug!("Uploading file at {:?}", wasm_path);
+        log::debug!(target: TRANSACTION_LOGS, "Uploading file at {:?}", wasm_path);
 
         let file_contents = std::fs::read(wasm_path.path())?;
         let mut e = write::GzEncoder::new(Vec::new(), Compression::default());
@@ -245,7 +250,7 @@ impl DaemonAsync {
 
         let result = sender.commit_tx(vec![store_msg], None).await?;
 
-        log::info!("Uploaded: {:?}", result.txhash);
+        log::info!(target: TRANSACTION_LOGS, "Uploading done: {:?}", result.txhash);
 
         let code_id = result.uploaded_code_id().unwrap();
 

--- a/cw-orch-daemon/src/keys/private.rs
+++ b/cw-orch-daemon/src/keys/private.rs
@@ -9,6 +9,7 @@ use bitcoin::{
     Network,
 };
 use cosmrs::tx::SignerPublicKey;
+use cw_orch_core::log::LOCAL_LOGS;
 use hkd32::mnemonic::{Phrase, Seed};
 use rand_core::OsRng;
 use secp256k1::Secp256k1;
@@ -121,7 +122,7 @@ impl PrivateKey {
 
         let vec_pk = public_key.serialize();
 
-        log::debug!("{:?}, public key", general_purpose::STANDARD.encode(vec_pk));
+        log::debug!(target: LOCAL_LOGS, "{:?}, public key", general_purpose::STANDARD.encode(vec_pk));
 
         let inj_key = InjectivePubKey { key: vec_pk.into() };
 

--- a/cw-orch-daemon/src/keys/public.rs
+++ b/cw-orch-daemon/src/keys/public.rs
@@ -1,5 +1,6 @@
 use crate::DaemonError;
 use bitcoin::bech32::{decode, encode, u5, FromBase32, ToBase32, Variant};
+use cw_orch_core::log::LOCAL_LOGS;
 pub use ed25519_dalek::VerifyingKey as Ed25519;
 use ring::digest::{Context, SHA256};
 use ripemd::{Digest as _, Ripemd160};
@@ -71,7 +72,7 @@ impl PublicKey {
                             source,
                         }
                     })?;
-                    log::debug!("{:#?}", hex::encode(&vu8));
+                    log::debug!(target: LOCAL_LOGS, "{:#?}", hex::encode(&vu8));
                     if vu8.starts_with(&BECH32_PUBKEY_DATA_PREFIX_SECP256K1) {
                         let public_key = PublicKey::public_key_from_pubkey(&vu8)?;
                         let raw = PublicKey::address_from_public_key(&public_key);
@@ -260,6 +261,7 @@ impl PublicKey {
         } else {
             // eprintln!("a_pub_ed_key {}", hex::encode(public_key));
             log::debug!(
+                target: LOCAL_LOGS,
                 "address_from_public_ed25519_key public key - {}",
                 hex::encode(public_key)
             );
@@ -281,6 +283,7 @@ impl PublicKey {
             // let address: Vec<u8> = ripe_result.to_vec();
             //     eprintln!("address_from_public_ed_key {}", hex::encode(&address));
             log::debug!(
+                target: LOCAL_LOGS,
                 "address_from_public_ed25519_key sha result - {}",
                 hex::encode(&address)
             );

--- a/cw-orch-daemon/src/keys/public.rs
+++ b/cw-orch-daemon/src/keys/public.rs
@@ -97,7 +97,7 @@ impl PublicKey {
                         }
                     })?;
                     //   log::debug!("{:#?}", hex::encode(&vu8));
-                    log::info!("ED25519 public keys are not fully supported");
+                    log::error!("ED25519 public keys are not fully supported");
                     if vu8.starts_with(&BECH32_PUBKEY_DATA_PREFIX_ED25519) {
                         //   let public_key = PublicKey::pubkey_from_ed25519_public_key(&vu8);
                         let raw = PublicKey::address_from_public_ed25519_key(&vu8)?;
@@ -225,7 +225,7 @@ impl PublicKey {
             let ed25519_pubkey = Ed25519::from_bytes(vec.try_into().unwrap())?;
             Ok(ed25519_pubkey.to_bytes().to_vec())
         } else {
-            log::info!("pub key does not start with BECH32 PREFIX");
+            log::error!("pub key does not start with BECH32 PREFIX");
             Err(DaemonError::Bech32DecodeErr)
         }
     }

--- a/cw-orch-daemon/src/lib.rs
+++ b/cw-orch-daemon/src/lib.rs
@@ -16,11 +16,11 @@ pub mod tx_resp;
 // expose these as mods as they can grow
 pub mod keys;
 pub mod live_mock;
+mod log;
 pub mod queriers;
 mod traits;
 pub mod tx_broadcaster;
 pub mod tx_builder;
-mod log;
 pub use self::{
     builder::*, channel::*, core::*, error::*, state::*, sync::*, traits::*, tx_resp::*,
 };

--- a/cw-orch-daemon/src/lib.rs
+++ b/cw-orch-daemon/src/lib.rs
@@ -20,7 +20,7 @@ pub mod queriers;
 mod traits;
 pub mod tx_broadcaster;
 pub mod tx_builder;
-
+mod log;
 pub use self::{
     builder::*, channel::*, core::*, error::*, state::*, sync::*, traits::*, tx_resp::*,
 };

--- a/cw-orch-daemon/src/log.rs
+++ b/cw-orch-daemon/src/log.rs
@@ -1,14 +1,12 @@
-
-
 // Prints a warning if log is disabled for the application
-pub fn print_if_disabled_log(){
+pub fn print_if_disabled_log() {
     // Here we check for logging capabilites. We want to help the users as much as possible
 
-    if !log::log_enabled!(log::Level::Info){
+    if !log::log_enabled!(log::Level::Info) {
         println!(
-"It seems like you haven't enabled logs. In order to do so, you have to : 
+            "It seems like you haven't enabled logs. In order to do so, you have to : 
     - use `env_logger::init()` inside your script
-    - use the env variable `RUST_LOG=INFO` for standard logs or `RUST_LOG=DEBUG` for more details")
+    - use the env variable `RUST_LOG=INFO` for standard logs or `RUST_LOG=DEBUG` for more details"
+        )
     }
 }
-        

--- a/cw-orch-daemon/src/log.rs
+++ b/cw-orch-daemon/src/log.rs
@@ -1,0 +1,14 @@
+
+
+// Prints a warning if log is disabled for the application
+pub fn print_if_disabled_log(){
+    // Here we check for logging capabilites. We want to help the users as much as possible
+
+    if !log::log_enabled!(log::Level::Info){
+        println!(
+"It seems like you haven't enabled logs. In order to do so, you have to : 
+    - use `env_logger::init()` inside your script
+    - use the env variable `RUST_LOG=INFO` for standard logs or `RUST_LOG=DEBUG` for more details")
+    }
+}
+        

--- a/cw-orch-daemon/src/log.rs
+++ b/cw-orch-daemon/src/log.rs
@@ -1,12 +1,11 @@
 // Prints a warning if log is disabled for the application
-pub fn print_if_disabled_log() {
-    // Here we check for logging capabilites. We want to help the users as much as possible
-
+pub fn print_if_log_disabled() {
+    // Here we check for logging capabilities.
     if !log::log_enabled!(log::Level::Info) {
         println!(
-            "It seems like you haven't enabled logs. In order to do so, you have to : 
-    - use `env_logger::init()` inside your script
-    - use the env variable `RUST_LOG=INFO` for standard logs or `RUST_LOG=DEBUG` for more details"
+            "Warning: It seems like you haven't enabled logs. In order to do so, you have to : 
+            - use `env_logger::init()` at the start of your script.
+            - Set the env variable `RUST_LOG=info` for standard logs. See https://docs.rs/env_logger/latest/env_logger/"
         )
     }
 }

--- a/cw-orch-daemon/src/queriers/node.rs
+++ b/cw-orch-daemon/src/queriers/node.rs
@@ -9,6 +9,7 @@ use cosmrs::{
     },
     tendermint::{Block, Time},
 };
+use cw_orch_core::log::QUERY_LOGS;
 use tonic::transport::Channel;
 
 use super::DaemonQuerier;
@@ -233,14 +234,14 @@ impl Node {
             match client.get_tx(request.clone()).await {
                 Ok(tx) => {
                     let resp = tx.into_inner().tx_response.unwrap();
-                    log::debug!("TX found: {:?}", resp);
+                    log::debug!(target: QUERY_LOGS, "TX found: {:?}", resp);
                     return Ok(resp.into());
                 }
                 Err(err) => {
                     // increase wait time
                     block_speed = (block_speed as f64 * 1.6) as u64;
-                    log::debug!("TX not found with error: {:?}", err);
-                    log::debug!("Waiting {block_speed} seconds");
+                    log::debug!(target: QUERY_LOGS, "TX not found with error: {:?}", err);
+                    log::debug!(target: QUERY_LOGS, "Waiting {block_speed} seconds");
                     tokio::time::sleep(Duration::from_secs(block_speed)).await;
                 }
             }
@@ -302,11 +303,12 @@ impl Node {
                 Ok(tx) => {
                     let resp = tx.into_inner().tx_responses;
                     if retry_on_empty && resp.is_empty() {
-                        log::debug!("Not TX by events found");
-                        log::debug!("Waiting 10s");
+                        log::debug!(target: QUERY_LOGS, "Not TX by events found");
+                        log::debug!(target: QUERY_LOGS, "Waiting 10s");
                         tokio::time::sleep(Duration::from_secs(10)).await;
                     } else {
                         log::debug!(
+                            target: QUERY_LOGS,
                             "TX found by events: {:?}",
                             resp.iter().map(|t| t.txhash.clone())
                         );
@@ -314,8 +316,8 @@ impl Node {
                     }
                 }
                 Err(err) => {
-                    log::debug!("TX not found with error: {:?}", err);
-                    log::debug!("Waiting 10s");
+                    log::debug!(target: QUERY_LOGS, "TX not found with error: {:?}", err);
+                    log::debug!(target: QUERY_LOGS, "Waiting 10s");
                     tokio::time::sleep(Duration::from_secs(10)).await;
                 }
             }

--- a/cw-orch-daemon/src/queriers/node.rs
+++ b/cw-orch-daemon/src/queriers/node.rs
@@ -303,7 +303,7 @@ impl Node {
                 Ok(tx) => {
                     let resp = tx.into_inner().tx_responses;
                     if retry_on_empty && resp.is_empty() {
-                        log::debug!(target: QUERY_LOGS, "Not TX by events found");
+                        log::debug!(target: QUERY_LOGS, "No TX found with events {:?}", events);
                         log::debug!(target: QUERY_LOGS, "Waiting 10s");
                         tokio::time::sleep(Duration::from_secs(10)).await;
                     } else {

--- a/cw-orch-daemon/src/sender.rs
+++ b/cw-orch-daemon/src/sender.rs
@@ -30,7 +30,7 @@ use cosmrs::{
     AccountId, Any,
 };
 use cosmwasm_std::Addr;
-use cw_orch_core::log::CONNECTIVITY_LOGS;
+use cw_orch_core::log::LOCAL_LOGS;
 use secp256k1::{All, Context, Secp256k1, Signing};
 use std::{convert::TryFrom, env, rc::Rc, str::FromStr};
 
@@ -77,7 +77,7 @@ impl Sender<All> {
             secp,
         };
         log::info!(
-            target: CONNECTIVITY_LOGS,
+            target: LOCAL_LOGS,
             "Interacting with {} using address: {}",
             daemon_state.chain_data.chain_id,
             sender.pub_addr_str()?

--- a/cw-orch-daemon/src/sender.rs
+++ b/cw-orch-daemon/src/sender.rs
@@ -30,6 +30,7 @@ use cosmrs::{
     AccountId, Any,
 };
 use cosmwasm_std::Addr;
+use cw_orch_core::log::CONNECTIVITY_LOGS;
 use secp256k1::{All, Context, Secp256k1, Signing};
 use std::{convert::TryFrom, env, rc::Rc, str::FromStr};
 
@@ -76,6 +77,7 @@ impl Sender<All> {
             secp,
         };
         log::info!(
+            target: CONNECTIVITY_LOGS,
             "Interacting with {} using address: {}",
             daemon_state.chain_data.chain_id,
             sender.pub_addr_str()?

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -4,6 +4,7 @@ use crate::{channel::GrpcChannel, networks::ChainKind};
 use cosmwasm_std::Addr;
 use cw_orch_core::{
     environment::{DeployDetails, StateInterface},
+    log::{CONNECTIVITY_LOGS, LOCAL_LOGS},
     CwEnvError,
 };
 use ibc_chain_registry::chain::ChainData;
@@ -44,7 +45,7 @@ impl DaemonState {
             return Err(DaemonError::GRPCListIsEmpty);
         }
 
-        log::info!("Found {} gRPC endpoints", chain_data.apis.grpc.len());
+        log::debug!(target: CONNECTIVITY_LOGS, "Found {} gRPC endpoints", chain_data.apis.grpc.len());
 
         // find working grpc channel
         let grpc_channel =
@@ -73,7 +74,7 @@ impl DaemonState {
         .into_string()
         .unwrap();
 
-        log::debug!("Using state file : {}", json_file_path);
+        log::debug!(target: LOCAL_LOGS, "Using state file : {}", json_file_path);
 
         // if the network we are connecting is a local kind, add it to the fn
         if chain_data.network_type == ChainKind::Local.to_string() {
@@ -114,6 +115,7 @@ impl DaemonState {
         };
 
         log::info!(
+            target: LOCAL_LOGS,
             "Writing daemon state JSON file: {:#?}",
             state.json_file_path
         );

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -73,7 +73,7 @@ impl DaemonState {
         .into_string()
         .unwrap();
 
-        log::info!("{}", json_file_path);
+        log::debug!("Using state file : {}", json_file_path);
 
         // if the network we are connecting is a local kind, add it to the fn
         if chain_data.network_type == ChainKind::Local.to_string() {

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -1,6 +1,6 @@
 use ibc_chain_registry::chain::ChainData;
 
-use crate::DaemonAsyncBuilder;
+use crate::{DaemonAsyncBuilder, log::print_if_disabled_log};
 
 use super::{super::error::DaemonError, core::Daemon};
 
@@ -72,6 +72,8 @@ impl DaemonBuilder {
             .ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
         // build the underlying daemon
         let daemon = rt_handle.block_on(DaemonAsyncBuilder::from(self.clone()).build())?;
+       
+        print_if_disabled_log();
 
         Ok(Daemon { rt_handle, daemon })
     }

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -1,6 +1,6 @@
 use ibc_chain_registry::chain::ChainData;
 
-use crate::{log::print_if_disabled_log, DaemonAsyncBuilder};
+use crate::DaemonAsyncBuilder;
 
 use super::{super::error::DaemonError, core::Daemon};
 
@@ -72,8 +72,6 @@ impl DaemonBuilder {
             .ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
         // build the underlying daemon
         let daemon = rt_handle.block_on(DaemonAsyncBuilder::from(self.clone()).build())?;
-
-        print_if_disabled_log();
 
         Ok(Daemon { rt_handle, daemon })
     }

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -1,6 +1,6 @@
 use ibc_chain_registry::chain::ChainData;
 
-use crate::{DaemonAsyncBuilder, log::print_if_disabled_log};
+use crate::{log::print_if_disabled_log, DaemonAsyncBuilder};
 
 use super::{super::error::DaemonError, core::Daemon};
 
@@ -72,7 +72,7 @@ impl DaemonBuilder {
             .ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
         // build the underlying daemon
         let daemon = rt_handle.block_on(DaemonAsyncBuilder::from(self.clone()).build())?;
-       
+
         print_if_disabled_log();
 
         Ok(Daemon { rt_handle, daemon })

--- a/cw-orch-daemon/src/traits.rs
+++ b/cw-orch-daemon/src/traits.rs
@@ -1,6 +1,7 @@
 use cw_orch_core::{
     contract::interface_traits::{CwOrchMigrate, CwOrchUpload},
     environment::TxResponse,
+    log::CONTRACT_LOGS,
 };
 
 use crate::{queriers::CosmWasm, Daemon, DaemonError};
@@ -58,7 +59,7 @@ pub trait ConditionalMigrate: CwOrchMigrate<Daemon> + ConditionalUpload {
         migrate_msg: &Self::MigrateMsg,
     ) -> Result<Option<TxResponse<Daemon>>, DaemonError> {
         if self.is_running_latest()? {
-            log::info!("{} is already running the latest code", self.id());
+            log::info!(target: CONTRACT_LOGS, "{} is already running the latest code", self.id());
             Ok(None)
         } else {
             Some(self.migrate(migrate_msg, self.code_id()?))

--- a/cw-orch-daemon/src/traits.rs
+++ b/cw-orch-daemon/src/traits.rs
@@ -59,7 +59,7 @@ pub trait ConditionalMigrate: CwOrchMigrate<Daemon> + ConditionalUpload {
         migrate_msg: &Self::MigrateMsg,
     ) -> Result<Option<TxResponse<Daemon>>, DaemonError> {
         if self.is_running_latest()? {
-            log::info!(target: CONTRACT_LOGS, "{} is already running the latest code", self.id());
+            log::info!(target: CONTRACT_LOGS, "Skipped migration. {} is already running the latest code", self.id());
             Ok(None)
         } else {
             Some(self.migrate(migrate_msg, self.code_id()?))

--- a/cw-orch-daemon/src/tx_broadcaster.rs
+++ b/cw-orch-daemon/src/tx_broadcaster.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse;
+use cw_orch_core::log::{TRANSACTION_LOGS, TX_RETRY_LOGS};
 use secp256k1::All;
 
 use crate::{
@@ -97,6 +98,7 @@ impl TxBroadcaster {
                         .average_block_speed(None)
                         .await?;
                     log::info!(
+                        target: TX_RETRY_LOGS,
                         "Retrying broadcasting tx in {} seconds because of {}",
                         block_speed,
                         s.reason
@@ -128,7 +130,7 @@ async fn broadcast_helper(
 ) -> Result<TxResponse, DaemonError> {
     let tx = tx_builder.build(wallet).await?;
     let tx_response = wallet.broadcast_tx(tx).await?;
-    log::debug!("tx broadcast response: {:?}", tx_response);
+    log::debug!(target: TRANSACTION_LOGS, "tx broadcast response: {:?}", tx_response);
 
     assert_broadcast_code_response(tx_response)
 }

--- a/cw-orch-daemon/src/tx_broadcaster.rs
+++ b/cw-orch-daemon/src/tx_broadcaster.rs
@@ -80,7 +80,10 @@ impl TxBroadcaster {
 
         // We try and broadcast once
         let mut tx_response = broadcast_helper(&mut tx_builder, wallet).await;
-
+        log::info!(
+            target: TX_RETRY_LOGS,
+            "Awaiting TX inclusion in block..."
+        );
         while tx_retry {
             tx_retry = false;
 
@@ -97,9 +100,9 @@ impl TxBroadcaster {
                     let block_speed = Node::new(wallet.channel())
                         .average_block_speed(None)
                         .await?;
-                    log::info!(
+                    log::warn!(
                         target: TX_RETRY_LOGS,
-                        "Retrying broadcasting tx in {} seconds because of {}",
+                        "Retrying broadcasting TX in {} seconds because of {}",
                         block_speed,
                         s.reason
                     );
@@ -130,7 +133,7 @@ async fn broadcast_helper(
 ) -> Result<TxResponse, DaemonError> {
     let tx = tx_builder.build(wallet).await?;
     let tx_response = wallet.broadcast_tx(tx).await?;
-    log::debug!(target: TRANSACTION_LOGS, "tx broadcast response: {:?}", tx_response);
+    log::debug!(target: TRANSACTION_LOGS, "TX broadcast response: {:?}", tx_response);
 
     assert_broadcast_code_response(tx_response)
 }

--- a/cw-orch-daemon/src/tx_builder.rs
+++ b/cw-orch-daemon/src/tx_builder.rs
@@ -7,6 +7,7 @@ use cosmrs::{
     tx::{self, Body, Fee, Raw, SequenceNumber, SignDoc, SignerInfo},
     Any, Coin,
 };
+use cw_orch_core::log::TRANSACTION_LOGS;
 use secp256k1::All;
 
 use super::{sender::Sender, DaemonError};
@@ -80,6 +81,7 @@ impl TxBuilder {
         let (tx_fee, gas_limit) =
             if let (Some(fee), Some(gas_limit)) = (self.fee_amount, self.gas_limit) {
                 log::debug!(
+                    target: TRANSACTION_LOGS,
                     "Using pre-defined fee and gas limits: {}, {}",
                     fee,
                     gas_limit
@@ -89,7 +91,7 @@ impl TxBuilder {
                 let sim_gas_used = wallet
                     .calculate_gas(&self.body, sequence, account_number)
                     .await?;
-                log::debug!("Simulated gas needed {:?}", sim_gas_used);
+                log::debug!(target: TRANSACTION_LOGS, "Simulated gas needed {:?}", sim_gas_used);
 
                 let gas_expected = if let Ok(gas_buffer) = env::var("CW_ORCH_GAS_BUFFER") {
                     sim_gas_used as f64 * gas_buffer.parse::<f64>()?
@@ -104,7 +106,7 @@ impl TxBuilder {
                         .max(wallet.daemon_state.chain_data.fees.fee_tokens[0].average_gas_price)
                         + 0.00001);
 
-                log::debug!("Calculated fee needed: {:?}", fee_amount);
+                log::debug!(target: TRANSACTION_LOGS, "Calculated fee needed: {:?}", fee_amount);
                 // set the gas limit of self for future txs
                 // there's no way to change the tx_builder body so simulation gas should remain the same as well
                 self.gas_limit = Some(gas_expected as u64);
@@ -119,6 +121,7 @@ impl TxBuilder {
         );
 
         log::debug!(
+            target: TRANSACTION_LOGS,
             "submitting tx: \n fee: {:?}\naccount_nr: {:?}\nsequence: {:?}",
             fee,
             account_number,

--- a/cw-orch-daemon/src/tx_builder.rs
+++ b/cw-orch-daemon/src/tx_builder.rs
@@ -122,7 +122,7 @@ impl TxBuilder {
 
         log::debug!(
             target: TRANSACTION_LOGS,
-            "submitting tx: \n fee: {:?}\naccount_nr: {:?}\nsequence: {:?}",
+            "submitting TX: \n fee: {:?}\naccount_nr: {:?}\nsequence: {:?}",
             fee,
             account_number,
             sequence

--- a/packages/cw-orch-core/src/contract/contract_instance.rs
+++ b/packages/cw-orch-core/src/contract/contract_instance.rs
@@ -3,6 +3,7 @@ use super::interface_traits::Uploadable;
 use crate::{
     environment::{CwEnv, IndexResponse, StateInterface, TxResponse},
     error::CwEnvError,
+    log::{CONTRACT_LOGS, TRANSACTION_LOGS},
 };
 
 use cosmwasm_std::{Addr, Coin};
@@ -52,12 +53,12 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
 
     /// Upload a contract given its source
     pub fn upload(&self, source: &impl Uploadable) -> Result<TxResponse<Chain>, CwEnvError> {
-        log::info!("Uploading {}", self.id);
+        log::info!(target: CONTRACT_LOGS, "Uploading {}", self.id);
         let resp = self.chain.upload(source).map_err(Into::into)?;
         let code_id = resp.uploaded_code_id()?;
         self.set_code_id(code_id);
-        log::info!("uploaded {} with code id {}", self.id, code_id);
-        log::debug!("Upload response: {:?}", resp);
+        log::info!(target: CONTRACT_LOGS, "Uploaded {} with code id {}", self.id, code_id);
+        log::debug!(target: TRANSACTION_LOGS, "Upload response: {:?}", resp);
         Ok(resp)
     }
 
@@ -67,11 +68,11 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
         msg: &E,
         coins: Option<&[Coin]>,
     ) -> Result<TxResponse<Chain>, CwEnvError> {
-        log::info!("Executing {} on {}", log_serialize_message(msg)?, self.id);
+        log::info!(target: CONTRACT_LOGS, "Executing {} on {}", log_serialize_message(msg)?, self.id);
         let resp = self
             .chain
             .execute(msg, coins.unwrap_or(&[]), &self.address()?);
-        log::debug!("execute response: {:?}", resp);
+        log::debug!(target: TRANSACTION_LOGS, "execute response: {:?}", resp);
         resp.map_err(Into::into)
     }
 
@@ -83,6 +84,7 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
         coins: Option<&[Coin]>,
     ) -> Result<TxResponse<Chain>, CwEnvError> {
         log::info!(
+            target: CONTRACT_LOGS,
             "Instantiating {} with msg {}",
             self.id,
             log_serialize_message(msg)?
@@ -102,9 +104,9 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
 
         self.set_address(&contract_address);
 
-        log::info!("Instantiated {} with address {}", self.id, contract_address);
+        log::info!(target: CONTRACT_LOGS, "Instantiated {} with address {}", self.id, contract_address);
 
-        log::debug!("Instantiate response: {:?}", resp);
+        log::debug!(target: TRANSACTION_LOGS, "Instantiate response: {:?}", resp);
 
         Ok(resp)
     }
@@ -115,6 +117,7 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
         query_msg: &Q,
     ) -> Result<T, CwEnvError> {
         log::info!(
+            target: CONTRACT_LOGS,
             "Querying {} on {}",
             log_serialize_message(query_msg)?,
             self.id
@@ -123,7 +126,7 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
             .chain
             .query(query_msg, &self.address()?)
             .map_err(Into::into)?;
-        log::debug!("Query response: {:?}", resp);
+        log::debug!(target: CONTRACT_LOGS, "Query response: {:?}", resp);
         Ok(resp)
     }
 
@@ -134,6 +137,7 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
         new_code_id: u64,
     ) -> Result<TxResponse<Chain>, CwEnvError> {
         log::info!(
+            target: CONTRACT_LOGS,
             "Migrating {:?} to code_id {}, with message {}",
             self.id,
             new_code_id,

--- a/packages/cw-orch-core/src/contract/contract_instance.rs
+++ b/packages/cw-orch-core/src/contract/contract_instance.rs
@@ -126,7 +126,7 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
             .chain
             .query(query_msg, &self.address()?)
             .map_err(Into::into)?;
-        log::debug!(target: CONTRACT_LOGS, "Query response: {:?}",  log_serialize_message(query_msg)?);
+        log::debug!(target: CONTRACT_LOGS, "Query response: {:?}",  log_serialize_message(&resp)?);
         Ok(resp)
     }
 

--- a/packages/cw-orch-core/src/contract/contract_instance.rs
+++ b/packages/cw-orch-core/src/contract/contract_instance.rs
@@ -143,7 +143,8 @@ impl<Chain: CwEnv + Clone> Contract<Chain> {
             new_code_id,
             log_serialize_message(migrate_msg)?
         );
-        let resp = self.chain
+        let resp = self
+            .chain
             .migrate(migrate_msg, new_code_id, &self.address()?)
             .map_err(Into::into)?;
 

--- a/packages/cw-orch-core/src/contract/paths.rs
+++ b/packages/cw-orch-core/src/contract/paths.rs
@@ -57,7 +57,7 @@ mod wasm_path {
 
 mod artifacts_dir {
     use super::WasmPath;
-    use crate::error::CwEnvError;
+    use crate::{error::CwEnvError, log::LOCAL_LOGS};
 
     use std::{env, fs, path::PathBuf};
 
@@ -120,7 +120,7 @@ mod artifacts_dir {
         pub fn auto(start_path: Option<String>) -> Self {
             // We find the artifacts dir automatically from the place that this function was invoked
             let workspace_dir = find_workspace_dir(start_path).join("artifacts");
-            log::debug!("Found artifacts dir at {:?}", workspace_dir);
+            log::debug!(target: LOCAL_LOGS, "Found artifacts dir at {:?}", workspace_dir);
             Self::new(workspace_dir)
         }
 

--- a/packages/cw-orch-core/src/lib.rs
+++ b/packages/cw-orch-core/src/lib.rs
@@ -2,7 +2,7 @@ pub mod contract;
 pub mod environment;
 
 mod error;
-
+pub mod log;
 pub use error::CwEnvError;
 
 pub use serde_json;

--- a/packages/cw-orch-core/src/log.rs
+++ b/packages/cw-orch-core/src/log.rs
@@ -1,0 +1,6 @@
+pub const CONNECTIVITY_LOGS: &str = "Connectivity";
+pub const QUERY_LOGS: &str = "Query";
+pub const CONTRACT_LOGS: &str = "Contract";
+pub const TRANSACTION_LOGS: &str = "Transaction";
+pub const TX_RETRY_LOGS: &str = "Transaction Retry";
+pub const LOCAL_LOGS: &str = "Local";


### PR DESCRIPTION
This PR aims at enhancing the logging of cw-orch by providing different styles when logging different information.

This also allows to show to users that logs are available and that they should enable logging capabilities.

Closes ORC-30

## Env variable classification proposition

- Local configuration (env variables, state file, path) --> Should we move that to debug ?
- Endpoint connection (gRPC + Account identification) `CONNECTIVITY_LOGS`
- Contract Interactions `CONTRACT_LOGS`
- Sending transactions + Receiving transactions responses `TRANSACTION_LOGS`
- Transaction sending retries `TX_RETRY_LOGS`

Here is an example log today : 

![image](https://github.com/AbstractSDK/cw-orchestrator/assets/44806566/9390acd3-0a6b-460f-81ba-b33ea0b865dc)

