### PR TITLE
Add WasmCodeQuerier support to ForkMock

### DIFF
--- a/cw-orch-daemon/src/traits.rs
+++ b/cw-orch-daemon/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::{queriers::CosmWasm, Daemon, DaemonError};
 use cosmwasm_std::ContractInfoResponse;
-use cw_orch_core::{contract::interface_traits::CwOrchUpload, environment::WasmCodeQuerier};
+use cw_orch_core::{contract::interface_traits::ContractInstance, environment::WasmCodeQuerier};
 
 impl WasmCodeQuerier for Daemon {
     /// Returns the checksum of provided code_id
@@ -12,7 +12,7 @@ impl WasmCodeQuerier for Daemon {
     }
 
     /// Returns the code_info structure of the provided contract
-    fn contract_info<T: CwOrchUpload<Self>>(
+    fn contract_info<T: ContractInstance<Self>>(
         &self,
         contract: &T,
     ) -> Result<ContractInfoResponse, DaemonError> {

--- a/cw-orch/src/osmosis_test_tube/core.rs
+++ b/cw-orch/src/osmosis_test_tube/core.rs
@@ -1,5 +1,6 @@
 use crate::contract::WasmPath;
 use crate::prelude::Uploadable;
+use cw_orch_core::environment::WasmCodeQuerier;
 use cw_orch_traits::stargate::Stargate;
 
 use cosmwasm_std::{Binary, BlockInfo, Coin, Timestamp, Uint128};
@@ -336,5 +337,18 @@ impl Stargate for OsmosisTestTube {
             data: Some(Binary(tx_response.raw_data)),
             events: tx_response.events,
         })
+    }
+}
+
+impl WasmCodeQuerier for OsmosisTestTube {
+    fn contract_hash(&self, _code_id: u64) -> Result<String, <Self as TxHandler>::Error> {
+        unimplemented!("contract_hash not implemented on osmosis_test_tube")
+    }
+
+    fn contract_info<T: cw_orch_core::contract::interface_traits::ContractInstance<Self>>(
+        &self,
+        _contract: &T,
+    ) -> Result<cosmwasm_std::ContractInfoResponse, <Self as TxHandler>::Error> {
+        unimplemented!("contract_info not implemented on osmosis_test_tube")
     }
 }

--- a/packages/cw-orch-core/src/contract/interface_traits.rs
+++ b/packages/cw-orch-core/src/contract/interface_traits.rs
@@ -197,7 +197,7 @@ pub trait CallAs<Chain: CwEnv>: CwOrchExecute<Chain> + ContractInstance<Chain> +
 impl<T: CwOrchExecute<Chain> + ContractInstance<Chain> + Clone, Chain: CwEnv> CallAs<Chain> for T {}
 
 /// Helper methods for conditional uploading of a contract.
-pub trait ConditionalUpload<Chain: WasmCodeQuerier>: CwOrchUpload<Chain> {
+pub trait ConditionalUpload<Chain: CwEnv>: CwOrchUpload<Chain> {
     /// Only upload the contract if it is not uploaded yet (checksum does not match)
     fn upload_if_needed(&self) -> Result<Option<TxResponse<Chain>>, CwEnvError> {
         if self.latest_is_uploaded()? {
@@ -232,10 +232,10 @@ pub trait ConditionalUpload<Chain: WasmCodeQuerier>: CwOrchUpload<Chain> {
     }
 }
 
-impl<T, Chain: WasmCodeQuerier> ConditionalUpload<Chain> for T where T: CwOrchUpload<Chain> {}
+impl<T, Chain: CwEnv> ConditionalUpload<Chain> for T where T: CwOrchUpload<Chain> {}
 
 /// Helper methods for conditional migration of a contract.
-pub trait ConditionalMigrate<Chain: WasmCodeQuerier>:
+pub trait ConditionalMigrate<Chain: CwEnv>:
     CwOrchMigrate<Chain> + ConditionalUpload<Chain>
 {
     /// Only migrate the contract if it is not on the latest code-id yet

--- a/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
+++ b/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
@@ -2,7 +2,7 @@
 
 use super::{ChainState, IndexResponse};
 use crate::{
-    contract::interface_traits::{CwOrchUpload, Uploadable},
+    contract::interface_traits::{ContractInstance, Uploadable},
     error::CwEnvError,
 };
 use cosmwasm_std::{Addr, BlockInfo, Coin, ContractInfoResponse};
@@ -10,8 +10,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 /// Signals a supported execution environment for CosmWasm contracts
-pub trait CwEnv: TxHandler + Clone {}
-impl<T: TxHandler + Clone> CwEnv for T {}
+pub trait CwEnv: TxHandler + WasmCodeQuerier + Clone {}
+impl<T: TxHandler + WasmCodeQuerier + Clone> CwEnv for T {}
 
 /// Response type for actions on an environment
 pub type TxResponse<Chain> = <Chain as TxHandler>::Response;
@@ -92,11 +92,11 @@ pub trait TxHandler: ChainState + Clone {
     }
 }
 
-pub trait WasmCodeQuerier: CwEnv {
+pub trait WasmCodeQuerier: TxHandler + Clone {
     /// Returns the checksum of provided code_id
     fn contract_hash(&self, code_id: u64) -> Result<String, <Self as TxHandler>::Error>;
     /// Returns the code_info structure of the provided contract
-    fn contract_info<T: CwOrchUpload<Self>>(
+    fn contract_info<T: ContractInstance<Self>>(
         &self,
         contract: &T,
     ) -> Result<ContractInfoResponse, <Self as TxHandler>::Error>;

--- a/packages/cw-orch-mock/src/core.rs
+++ b/packages/cw-orch-mock/src/core.rs
@@ -6,7 +6,7 @@ use cw_utils::NativeBalance;
 use serde::{de::DeserializeOwned, Serialize};
 
 use cw_orch_core::{
-    contract::interface_traits::{CwOrchUpload, Uploadable},
+    contract::interface_traits::{ContractInstance, Uploadable},
     environment::{ChainState, IndexResponse, StateInterface},
     environment::{TxHandler, WasmCodeQuerier},
     CwEnvError,
@@ -320,7 +320,7 @@ impl WasmCodeQuerier for Mock {
     }
 
     /// Returns the code_info structure of the provided contract
-    fn contract_info<T: CwOrchUpload<Self>>(
+    fn contract_info<T: ContractInstance<Self>>(
         &self,
         contract: &T,
     ) -> Result<ContractInfoResponse, CwEnvError> {


### PR DESCRIPTION
- Add `WasmCodeQuerier` to `CwEnv` trait bound
- update conditional trait's bounds
