### PR TITLE
Add readonly flag daemon state

### DIFF
--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -63,7 +63,7 @@ impl DaemonAsyncBuilder {
             .deployment_id
             .clone()
             .unwrap_or(DEFAULT_DEPLOYMENT.to_string());
-        let state = Rc::new(DaemonState::new(chain, deployment_id).await?);
+        let state = Rc::new(DaemonState::new(chain, deployment_id, false).await?);
         // if mnemonic provided, use it. Else use env variables to retrieve mnemonic
         let sender = if let Some(mnemonic) = &self.mnemonic {
             Sender::from_mnemonic(&state, mnemonic)?

--- a/cw-orch-daemon/src/error.rs
+++ b/cw-orch-daemon/src/error.rs
@@ -114,6 +114,8 @@ pub enum DaemonError {
     InsufficientFee(String),
     #[error("Not enough balance, expected {expected}, found {current}")]
     NotEnoughBalance { expected: Coin, current: Coin },
+    #[error("Can't set the daemon state, it's read-only")]
+    StateReadOnly,
 }
 
 impl DaemonError {

--- a/cw-orch-daemon/src/json_file.rs
+++ b/cw-orch-daemon/src/json_file.rs
@@ -1,3 +1,4 @@
+use crate::DaemonError;
 use serde_json::{from_reader, json, Value};
 use std::fs::{File, OpenOptions};
 
@@ -41,9 +42,9 @@ pub fn write(filename: &String, chain_id: &String, network_id: &String, deploy_i
     serde_json::to_writer_pretty(File::create(filename).unwrap(), &json).unwrap();
 }
 
-pub fn read(filename: &String) -> Value {
+pub fn read(filename: &String) -> Result<Value, DaemonError> {
     let file =
         File::open(filename).unwrap_or_else(|_| panic!("File should be present at {}", filename));
-    let json: serde_json::Value = from_reader(file).unwrap();
-    json
+    let json: serde_json::Value = from_reader(file)?;
+    Ok(json)
 }


### PR DESCRIPTION
This PR aims at adding the possibility to load the daemon state in read-only mode.
This is particularly helpful when using the daemon state in a clone-testing environment