### PR TITLE
Add `local_hash` function to `WasmCodeQuerier` trait and implement it for envs

### DIFF
--- a/packages/cw-orch-core/src/contract/interface_traits.rs
+++ b/packages/cw-orch-core/src/contract/interface_traits.rs
@@ -217,7 +217,7 @@ pub trait ConditionalUpload<Chain: CwEnv>: CwOrchUpload<Chain> {
         let on_chain_hash = chain
             .contract_hash(latest_uploaded_code_id)
             .map_err(Into::into)?;
-        let local_hash = self.wasm().checksum()?;
+        let local_hash = chain.local_hash(self)?;
         Ok(local_hash == on_chain_hash)
     }
 

--- a/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
+++ b/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
@@ -100,6 +100,14 @@ pub trait WasmCodeQuerier: TxHandler + Clone {
         &self,
         contract: &T,
     ) -> Result<ContractInfoResponse, <Self as TxHandler>::Error>;
+
+    /// Returns the checksum of the WASM file if the env supports it. Will re-upload every time if not supported.
+    fn local_hash<T: Uploadable + ContractInstance<Self>>(
+        &self,
+        contract: &T,
+    ) -> Result<String, CwEnvError> {
+        contract.wasm().checksum()
+    }
 }
 
 pub trait BankQuerier: TxHandler {

--- a/packages/cw-orch-mock/Cargo.toml
+++ b/packages/cw-orch-mock/Cargo.toml
@@ -15,6 +15,7 @@ cosmwasm-std = { workspace = true }
 cw-multi-test = { workspace = true }
 cw-utils = { workspace = true }
 serde = { workspace = true }
+sha256 = { workspace = true }
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/packages/cw-orch-mock/src/core.rs
+++ b/packages/cw-orch-mock/src/core.rs
@@ -331,6 +331,15 @@ impl WasmCodeQuerier for Mock {
             .query_wasm_contract_info(contract.address()?)?;
         Ok(info)
     }
+
+    fn local_hash<T: Uploadable + ContractInstance<Mock>>(
+        &self,
+        contract: &T,
+    ) -> Result<String, CwEnvError> {
+        // We return the hashed contract-id.
+        // This will cause the logic to never re-upload a contract if it has the same contract-id.
+        Ok(sha256::digest(contract.id().as_bytes()))
+    }
 }
 
 impl BankQuerier for Mock {


### PR DESCRIPTION
Required for `ConditionalUpload` to work in Mock environments.