### PR TITLE
Generalized querier getter

### DIFF
--- a/cw-orch-daemon/src/queriers.rs
+++ b/cw-orch-daemon/src/queriers.rs
@@ -47,6 +47,7 @@ macro_rules! cosmos_query {
 mod authz;
 mod bank;
 mod cosmwasm;
+mod env;
 mod feegrant;
 mod gov;
 mod ibc;
@@ -54,11 +55,11 @@ mod node;
 mod staking;
 
 pub use authz::Authz;
-pub use bank::{cosmrs_to_cosmwasm_coins, Bank};
-pub use cosmwasm::CosmWasm;
+pub use bank::{cosmrs_to_cosmwasm_coins, Bank, DaemonBankQuerier};
+pub use cosmwasm::{CosmWasm, DaemonWasmQuerier};
 pub use feegrant::Feegrant;
 pub use ibc::Ibc;
-pub use node::Node;
+pub use node::{DaemonNodeQuerier, Node};
 
 // this two containt structs that are helpers for the queries
 pub use gov::*;

--- a/cw-orch-daemon/src/queriers/bank.rs
+++ b/cw-orch-daemon/src/queriers/bank.rs
@@ -1,7 +1,7 @@
 use crate::{cosmos_modules, error::DaemonError, Daemon};
 use cosmrs::proto::cosmos::base::{query::v1beta1::PageRequest, v1beta1::Coin};
 use cosmwasm_std::StdError;
-use cw_orch_core::environment::queriers::{bank::{BankQuerier}, Querier, QuerierGetter};
+use cw_orch_core::environment::{BankQuerier, Querier, QuerierGetter};
 use tokio::runtime::Handle;
 use tonic::transport::Channel;
 
@@ -168,7 +168,6 @@ impl QuerierGetter<DaemonBankQuerier> for Daemon {
 }
 
 impl BankQuerier for DaemonBankQuerier {
-
     fn balance(
         &self,
         address: impl Into<String>,

--- a/cw-orch-daemon/src/queriers/bank.rs
+++ b/cw-orch-daemon/src/queriers/bank.rs
@@ -1,7 +1,7 @@
 use crate::{cosmos_modules, error::DaemonError, Daemon};
 use cosmrs::proto::cosmos::base::{query::v1beta1::PageRequest, v1beta1::Coin};
 use cosmwasm_std::StdError;
-use cw_orch_core::environment::queriers::bank::{BankQuerier, BankQuerierGetter};
+use cw_orch_core::environment::queriers::{bank::{BankQuerier}, Querier, QuerierGetter};
 use tokio::runtime::Handle;
 use tonic::transport::Channel;
 
@@ -157,16 +157,17 @@ impl DaemonBankQuerier {
     }
 }
 
-impl BankQuerierGetter<DaemonError> for Daemon {
-    type Querier = DaemonBankQuerier;
+impl Querier for DaemonBankQuerier {
+    type Error = DaemonError;
+}
 
-    fn bank_querier(&self) -> Self::Querier {
+impl QuerierGetter<DaemonBankQuerier> for Daemon {
+    fn querier(&self) -> DaemonBankQuerier {
         DaemonBankQuerier::new(self)
     }
 }
 
 impl BankQuerier for DaemonBankQuerier {
-    type Error = DaemonError;
 
     fn balance(
         &self,

--- a/cw-orch-daemon/src/queriers/cosmwasm.rs
+++ b/cw-orch-daemon/src/queriers/cosmwasm.rs
@@ -1,7 +1,7 @@
 use crate::{cosmos_modules, error::DaemonError, Daemon};
 use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmwasm_std::{from_json, to_json_binary, CodeInfoResponse, ContractInfoResponse};
-use cw_orch_core::environment::queriers::wasm::{WasmQuerier, WasmQuerierGetter};
+use cw_orch_core::environment::{Querier, QuerierGetter, WasmQuerier};
 use tokio::runtime::Handle;
 use tonic::transport::Channel;
 
@@ -187,17 +187,17 @@ impl DaemonWasmQuerier {
     }
 }
 
-impl WasmQuerierGetter<DaemonError> for Daemon {
-    type Querier = DaemonWasmQuerier;
-
-    fn wasm_querier(&self) -> Self::Querier {
+impl QuerierGetter<DaemonWasmQuerier> for Daemon {
+    fn querier(&self) -> DaemonWasmQuerier {
         DaemonWasmQuerier::new(self)
     }
 }
 
-impl WasmQuerier for DaemonWasmQuerier {
+impl Querier for DaemonWasmQuerier {
     type Error = DaemonError;
+}
 
+impl WasmQuerier for DaemonWasmQuerier {
     fn code_id_hash(&self, code_id: u64) -> Result<String, Self::Error> {
         self.rt_handle
             .block_on(CosmWasm::new(self.channel.clone()).code_id_hash(code_id))

--- a/cw-orch-daemon/src/queriers/cosmwasm.rs
+++ b/cw-orch-daemon/src/queriers/cosmwasm.rs
@@ -228,7 +228,7 @@ impl WasmQuerier for DaemonWasmQuerier {
         Ok(c)
     }
 
-    fn contract_raw_state(
+    fn raw_query(
         &self,
         address: impl Into<String>,
         query_data: Vec<u8>,
@@ -240,7 +240,7 @@ impl WasmQuerier for DaemonWasmQuerier {
         Ok(response.data)
     }
 
-    fn contract_smart_state<Q: serde::Serialize, T: serde::de::DeserializeOwned>(
+    fn smart_query<Q: serde::Serialize, T: serde::de::DeserializeOwned>(
         &self,
         address: impl Into<String>,
         query_data: &Q,

--- a/cw-orch-daemon/src/queriers/env.rs
+++ b/cw-orch-daemon/src/queriers/env.rs
@@ -1,0 +1,14 @@
+use cw_orch_core::environment::{EnvironmentInfo, EnvironmentQuerier};
+
+use crate::Daemon;
+
+impl EnvironmentQuerier for Daemon {
+    fn env_info(&self) -> EnvironmentInfo {
+        let state = &self.daemon.sender.daemon_state;
+        EnvironmentInfo {
+            chain_id: state.chain_data.chain_id.to_string(),
+            chain_name: state.chain_data.chain_name.clone(),
+            deployment_id: state.deployment_id.clone(),
+        }
+    }
+}

--- a/cw-orch-daemon/src/queriers/node.rs
+++ b/cw-orch-daemon/src/queriers/node.rs
@@ -11,7 +11,7 @@ use cosmrs::{
 };
 use cosmwasm_std::BlockInfo;
 use cw_orch_core::{
-    environment::queriers::node::{NodeQuerier, NodeQuerierGetter},
+    environment::{NodeQuerier, Querier, QuerierGetter},
     log::query_target,
     CwOrchEnvVars,
 };
@@ -346,17 +346,17 @@ impl DaemonNodeQuerier {
     }
 }
 
-impl NodeQuerierGetter<DaemonError> for Daemon {
-    type Querier = DaemonNodeQuerier;
-
-    fn node_querier(&self) -> Self::Querier {
+impl QuerierGetter<DaemonNodeQuerier> for Daemon {
+    fn querier(&self) -> DaemonNodeQuerier {
         DaemonNodeQuerier::new(self)
     }
 }
 
-impl NodeQuerier for DaemonNodeQuerier {
+impl Querier for DaemonNodeQuerier {
     type Error = DaemonError;
+}
 
+impl NodeQuerier for DaemonNodeQuerier {
     type Response = CosmTxResponse;
 
     fn latest_block(&self) -> Result<cosmwasm_std::BlockInfo, Self::Error> {

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -217,30 +217,7 @@ impl QueryHandler for Daemon {
         Ok(())
     }
 
-    fn block_info(&self) -> Result<cosmwasm_std::BlockInfo, DaemonError> {
-        let block = self
-            .rt_handle
-            .block_on(self.query_client::<Node>().latest_block())?;
-        let since_epoch = block.header.time.duration_since(Time::unix_epoch())?;
-        let time = cosmwasm_std::Timestamp::from_nanos(since_epoch.as_nanos() as u64);
-        Ok(cosmwasm_std::BlockInfo {
-            height: block.header.height.value(),
-            time,
-            chain_id: block.header.chain_id.to_string(),
-        })
-    }
-
-    fn query<
-        Q: serde::Serialize + std::fmt::Debug,
-        T: serde::Serialize + serde::de::DeserializeOwned,
-    >(
-        &self,
-        query_msg: &Q,
-        contract_address: &cosmwasm_std::Addr,
-    ) -> Result<T, Self::Error> {
-        self.rt_handle
-            .block_on(self.daemon.query(query_msg, contract_address))
-    }
+    
 }
 
 impl DefaultQueriers for Daemon {

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -6,7 +6,6 @@ use crate::{
     CosmTxResponse, DaemonBuilder, DaemonError, DaemonState,
 };
 
-use cosmrs::tendermint::Time;
 use cosmwasm_std::{Addr, Coin};
 use cw_orch_core::{
     contract::{interface_traits::Uploadable, WasmPath},
@@ -216,8 +215,6 @@ impl QueryHandler for Daemon {
         }
         Ok(())
     }
-
-    
 }
 
 impl DefaultQueriers for Daemon {

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use super::super::{sender::Wallet, DaemonAsync};
 use crate::{
-    queriers::{DaemonQuerier, Node},
+    queriers::{DaemonBankQuerier, DaemonNodeQuerier, DaemonQuerier, DaemonWasmQuerier, Node},
     CosmTxResponse, DaemonBuilder, DaemonError, DaemonState,
 };
 
@@ -10,7 +10,7 @@ use cosmrs::tendermint::Time;
 use cosmwasm_std::{Addr, Coin};
 use cw_orch_core::{
     contract::{interface_traits::Uploadable, WasmPath},
-    environment::{queriers::QueryHandler, ChainState, TxHandler},
+    environment::{ChainState, DefaultQueriers, QueryHandler, TxHandler},
 };
 use cw_orch_traits::stargate::Stargate;
 use serde::Serialize;
@@ -241,4 +241,10 @@ impl QueryHandler for Daemon {
         self.rt_handle
             .block_on(self.daemon.query(query_msg, contract_address))
     }
+}
+
+impl DefaultQueriers for Daemon {
+    type B = DaemonBankQuerier;
+    type W = DaemonWasmQuerier;
+    type N = DaemonNodeQuerier;
 }

--- a/cw-orch-daemon/tests/authz.rs
+++ b/cw-orch-daemon/tests/authz.rs
@@ -13,7 +13,7 @@ mod tests {
         bank::v1beta1::MsgSend,
     };
     use cosmwasm_std::coins;
-    use cw_orch_core::environment::{BankQuerier, TxHandler};
+    use cw_orch_core::environment::{BankQuerier, DefaultQueriers, QueryHandler, TxHandler};
     use cw_orch_daemon::{queriers::Authz, Daemon};
     use cw_orch_networks::networks::LOCAL_JUNO;
     use cw_orch_traits::Stargate;
@@ -138,8 +138,9 @@ mod tests {
 
         // the balance of the grantee whould be 6_000_000 or close
 
-        let grantee_balance =
-            daemon.balance(grantee.clone(), Some(LOCAL_JUNO.gas_denom.to_string()))?;
+        let grantee_balance = daemon
+            .bank_querier()
+            .balance(grantee.clone(), Some(LOCAL_JUNO.gas_denom.to_string()))?;
 
         assert_eq!(grantee_balance.first().unwrap().amount.u128(), 6_000_000);
 

--- a/cw-orch/examples/complex_osmosis_test_tube.rs
+++ b/cw-orch/examples/complex_osmosis_test_tube.rs
@@ -4,10 +4,7 @@ use counter_contract::{
     CounterContract, CounterExecuteMsgFns, CounterQueryMsgFns,
 };
 
-use cw_orch::prelude::bank::BankQuerier;
-use cw_orch::prelude::bank::BankQuerierGetter;
-use cw_orch::prelude::{CallAs, ContractInstance, OsmosisTestTube};
-use cw_orch::prelude::{CwOrchExecute, CwOrchInstantiate, CwOrchUpload};
+use cw_orch::prelude::*;
 use cw_orch_traits::Stargate;
 use osmosis_std::types::{
     cosmos::base::v1beta1::Coin,

--- a/cw-orch/examples/complex_testnet_daemon.rs
+++ b/cw-orch/examples/complex_testnet_daemon.rs
@@ -3,12 +3,7 @@ use counter_contract::{
     msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg},
     CounterContract, CounterExecuteMsgFns, CounterQueryMsgFns,
 };
-use cw_orch::prelude::bank::BankQuerier;
-use cw_orch::prelude::bank::BankQuerierGetter;
-use cw_orch::prelude::{
-    ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Daemon,
-    TxHandler,
-};
+use cw_orch::prelude::*;
 use cw_orch_traits::Stargate;
 use osmosis_std::types::{
     cosmos::base::v1beta1::Coin,

--- a/cw-orch/src/osmosis_test_tube/core.rs
+++ b/cw-orch/src/osmosis_test_tube/core.rs
@@ -4,9 +4,7 @@ use crate::contract::WasmPath;
 use crate::prelude::Uploadable;
 use cosmwasm_std::{Addr, StdResult};
 
-use cw_orch_core::environment::{
-    BankQuerier, BankSetter, EnvironmentInfo, EnvironmentQuerier, WasmCodeQuerier,
-};
+use cw_orch_core::environment::{BankQuerier, BankSetter, DefaultQueriers};
 use cw_orch_traits::stargate::Stargate;
 
 use cosmwasm_std::{Binary, Coin, Uint128};
@@ -35,6 +33,8 @@ use crate::{
 use crate::mock::MockState;
 
 pub use osmosis_test_tube;
+
+use super::queriers::bank::OsmosisTestTubeBankQuerier;
 
 /// Wrapper around a osmosis-test-tube [`OsmosisTestApp`](osmosis_test_tube::OsmosisTestApp) backend.
 ///
@@ -272,6 +272,8 @@ impl<S: StateInterface> TxHandler for OsmosisTestTube<S> {
 }
 
 impl BankSetter for OsmosisTestTube {
+    type T = OsmosisTestTubeBankQuerier;
+
     /// It's impossible to set the balance of an address directly in OsmosisTestTub
     /// So for this implementation, we use a weird algorithm
     fn set_balance(
@@ -316,10 +318,7 @@ pub(crate) fn to_cosmwasm_coin(
 pub mod tests {
     use cosmwasm_std::{coins, ContractInfoResponse};
 
-    use cw_orch_core::environment::queriers::{
-        bank::{BankQuerier, BankQuerierGetter},
-        wasm::{WasmQuerier, WasmQuerierGetter},
-    };
+    use cw_orch_core::environment::*;
     use osmosis_test_tube::Account;
 
     use super::OsmosisTestTube;

--- a/cw-orch/src/osmosis_test_tube/queriers/bank.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/bank.rs
@@ -3,8 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use cosmwasm_std::coin;
 use cw_orch_core::{
     environment::{
-        queriers::bank::{BankQuerier, BankQuerierGetter},
-        StateInterface, TxHandler,
+        Querier, StateInterface, {BankQuerier, QuerierGetter},
     },
     CwEnvError,
 };
@@ -15,11 +14,11 @@ use crate::osmosis_test_tube::{map_err, to_cosmwasm_coin, OsmosisTestTube};
 use osmosis_test_tube::osmosis_std::types::cosmos::bank::v1beta1::{
     QueryAllBalancesRequest, QueryBalanceRequest,
 };
-pub struct MockBankQuerier {
+pub struct OsmosisTestTubeBankQuerier {
     app: Rc<RefCell<OsmosisTestApp>>,
 }
 
-impl MockBankQuerier {
+impl OsmosisTestTubeBankQuerier {
     fn new<S: StateInterface>(mock: &OsmosisTestTube<S>) -> Self {
         Self {
             app: mock.app.clone(),
@@ -27,17 +26,17 @@ impl MockBankQuerier {
     }
 }
 
-impl<S: StateInterface> BankQuerierGetter<<Self as TxHandler>::Error> for OsmosisTestTube<S> {
-    type Querier = MockBankQuerier;
+impl Querier for OsmosisTestTubeBankQuerier {
+    type Error = CwEnvError;
+}
 
-    fn bank_querier(&self) -> Self::Querier {
-        MockBankQuerier::new(self)
+impl<S: StateInterface> QuerierGetter<OsmosisTestTubeBankQuerier> for OsmosisTestTube<S> {
+    fn querier(&self) -> OsmosisTestTubeBankQuerier {
+        OsmosisTestTubeBankQuerier::new(self)
     }
 }
 
-impl BankQuerier for MockBankQuerier {
-    type Error = CwEnvError;
-
+impl BankQuerier for OsmosisTestTubeBankQuerier {
     fn balance(
         &self,
         address: impl Into<String>,

--- a/cw-orch/src/osmosis_test_tube/queriers/env.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/env.rs
@@ -1,0 +1,19 @@
+use cw_orch_core::environment::{
+    EnvironmentInfo, EnvironmentQuerier, QueryHandler, StateInterface,
+};
+
+use crate::prelude::OsmosisTestTube;
+
+impl<S: StateInterface> EnvironmentQuerier for OsmosisTestTube<S> {
+    fn env_info(&self) -> EnvironmentInfo {
+        let block = self.block_info().unwrap();
+        let chain_id = block.chain_id;
+        let chain_name = chain_id.rsplitn(2, '-').collect::<Vec<_>>()[1].to_string();
+
+        EnvironmentInfo {
+            chain_id,
+            chain_name,
+            deployment_id: "default".to_string(),
+        }
+    }
+}

--- a/cw-orch/src/osmosis_test_tube/queriers/mod.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/mod.rs
@@ -27,28 +27,6 @@ impl<S: StateInterface> QueryHandler for OsmosisTestTube<S> {
     fn next_block(&self) -> Result<(), CwOrchError> {
         panic!("Can't wait blocks on osmosis_test_tube")
     }
-
-    fn block_info(&self) -> Result<cosmwasm_std::BlockInfo, CwOrchError> {
-        Ok(BlockInfo {
-            chain_id: "osmosis-1".to_string(),
-            height: self.app.borrow().get_block_height().try_into().unwrap(),
-            time: Timestamp::from_nanos(
-                self.app.borrow().get_block_time_nanos().try_into().unwrap(),
-            ),
-        })
-    }
-
-    fn query<Q: Serialize + Debug, T: Serialize + DeserializeOwned>(
-        &self,
-        query_msg: &Q,
-        contract_address: &Addr,
-    ) -> Result<T, CwOrchError> {
-        let query = Wasm::new(&*self.app.borrow())
-            .query(contract_address.as_ref(), query_msg)
-            .map_err(map_err)?;
-
-        Ok(query)
-    }
 }
 
 impl<S: StateInterface> DefaultQueriers for OsmosisTestTube<S> {

--- a/cw-orch/src/osmosis_test_tube/queriers/mod.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/mod.rs
@@ -1,6 +1,6 @@
 use crate::error::CwOrchError;
 use cosmwasm_std::{Addr, BlockInfo, Timestamp};
-use cw_orch_core::environment::{queriers::QueryHandler, StateInterface};
+use cw_orch_core::environment::{DefaultQueriers, QueryHandler, StateInterface};
 use osmosis_test_tube::{Module, Wasm};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 use super::{map_err, OsmosisTestTube};
 
 pub mod bank;
+pub mod env;
 pub mod node;
 pub mod wasm;
 
@@ -48,4 +49,10 @@ impl<S: StateInterface> QueryHandler for OsmosisTestTube<S> {
 
         Ok(query)
     }
+}
+
+impl<S: StateInterface> DefaultQueriers for OsmosisTestTube<S> {
+    type B = bank::OsmosisTestTubeBankQuerier;
+    type W = wasm::OsmosisTestTubeWasmQuerier;
+    type N = node::OsmosisTestTubeNodeQuerier;
 }

--- a/cw-orch/src/osmosis_test_tube/queriers/mod.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/mod.rs
@@ -1,11 +1,8 @@
 use crate::error::CwOrchError;
-use cosmwasm_std::{Addr, BlockInfo, Timestamp};
-use cw_orch_core::environment::{DefaultQueriers, QueryHandler, StateInterface};
-use osmosis_test_tube::{Module, Wasm};
-use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
 
-use super::{map_err, OsmosisTestTube};
+use cw_orch_core::environment::{DefaultQueriers, QueryHandler, StateInterface};
+
+use super::OsmosisTestTube;
 
 pub mod bank;
 mod env;

--- a/cw-orch/src/osmosis_test_tube/queriers/node.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/node.rs
@@ -3,10 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use cosmwasm_std::{BlockInfo, Timestamp};
 use cw_multi_test::AppResponse;
 use cw_orch_core::{
-    environment::{
-        queriers::node::{NodeQuerier, NodeQuerierGetter},
-        StateInterface, TxHandler,
-    },
+    environment::{NodeQuerier, Querier, QuerierGetter, StateInterface},
     CwEnvError,
 };
 use osmosis_test_tube::OsmosisTestApp;
@@ -25,18 +22,18 @@ impl OsmosisTestTubeNodeQuerier {
     }
 }
 
-impl<S: StateInterface> NodeQuerierGetter<<Self as TxHandler>::Error> for OsmosisTestTube<S> {
-    type Querier = OsmosisTestTubeNodeQuerier;
+impl Querier for OsmosisTestTubeNodeQuerier {
+    type Error = CwEnvError;
+}
 
-    fn node_querier(&self) -> Self::Querier {
+impl<S: StateInterface> QuerierGetter<OsmosisTestTubeNodeQuerier> for OsmosisTestTube<S> {
+    fn querier(&self) -> OsmosisTestTubeNodeQuerier {
         OsmosisTestTubeNodeQuerier::new(self)
     }
 }
 
 impl NodeQuerier for OsmosisTestTubeNodeQuerier {
     type Response = AppResponse;
-    type Error = CwEnvError;
-
     fn latest_block(&self) -> Result<cosmwasm_std::BlockInfo, Self::Error> {
         Ok(BlockInfo {
             chain_id: "osmosis-1".to_string(),

--- a/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
@@ -2,10 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use cosmwasm_std::{from_json, to_json_vec, CodeInfoResponse, ContractInfoResponse};
 use cw_orch_core::{
-    environment::{
-        queriers::wasm::{WasmQuerier, WasmQuerierGetter},
-        StateInterface, TxHandler,
-    },
+    environment::{Querier, QuerierGetter, StateInterface, WasmQuerier},
     CwEnvError,
 };
 use osmosis_test_tube::{OsmosisTestApp, Runner};
@@ -16,6 +13,7 @@ use osmosis_std::types::cosmwasm::wasm::v1::{
     QueryRawContractStateRequest, QueryRawContractStateResponse, QuerySmartContractStateRequest,
     QuerySmartContractStateResponse,
 };
+
 pub struct OsmosisTestTubeWasmQuerier {
     app: Rc<RefCell<OsmosisTestApp>>,
 }
@@ -28,16 +26,17 @@ impl OsmosisTestTubeWasmQuerier {
     }
 }
 
-impl<S: StateInterface> WasmQuerierGetter<<Self as TxHandler>::Error> for OsmosisTestTube<S> {
-    type Querier = OsmosisTestTubeWasmQuerier;
+impl Querier for OsmosisTestTubeWasmQuerier {
+    type Error = CwEnvError;
+}
 
-    fn wasm_querier(&self) -> Self::Querier {
+impl<S: StateInterface> QuerierGetter<OsmosisTestTubeWasmQuerier> for OsmosisTestTube<S> {
+    fn querier(&self) -> OsmosisTestTubeWasmQuerier {
         OsmosisTestTubeWasmQuerier::new(self)
     }
 }
-impl WasmQuerier for OsmosisTestTubeWasmQuerier {
-    type Error = CwEnvError;
 
+impl WasmQuerier for OsmosisTestTubeWasmQuerier {
     fn code_id_hash(&self, code_id: u64) -> Result<String, Self::Error> {
         let code_info_result: QueryCodeResponse = self
             .app

--- a/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
@@ -87,7 +87,7 @@ impl WasmQuerier for OsmosisTestTubeWasmQuerier {
         Ok(contract_info)
     }
 
-    fn contract_raw_state(
+    fn raw_query(
         &self,
         address: impl Into<String>,
         query_data: Vec<u8>,
@@ -109,7 +109,7 @@ impl WasmQuerier for OsmosisTestTubeWasmQuerier {
         Ok(result)
     }
 
-    fn contract_smart_state<Q: serde::Serialize, T: serde::de::DeserializeOwned>(
+    fn smart_query<Q: serde::Serialize, T: serde::de::DeserializeOwned>(
         &self,
         address: impl Into<String>,
         query_data: &Q,

--- a/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
@@ -119,7 +119,7 @@ impl WasmQuerier for OsmosisTestTubeWasmQuerier {
             .app
             .borrow()
             .query::<_, QuerySmartContractStateResponse>(
-                "/cosmwasm.wasm.v1.Query/RawContractState",
+                "/cosmwasm.wasm.v1.Query/SmartContractState",
                 &QuerySmartContractStateRequest {
                     address: address.clone(),
                     query_data: to_json_vec(query_data)?,

--- a/cw-orch/src/prelude.rs
+++ b/cw-orch/src/prelude.rs
@@ -25,8 +25,10 @@ pub use crate::environment::StateInterface;
 pub use crate::environment::IndexResponse;
 
 // Environment
-pub use crate::environment::{CwEnv, QueryHandler, TxHandler, TxResponse};
-pub use cw_orch_core::environment::queriers::*;
+pub use crate::environment::{
+    BankQuerier, BankSetter, CwEnv, DefaultQueriers, EnvironmentInfo, EnvironmentQuerier,
+    NodeQuerier, QuerierGetter, QueryHandler, TxHandler, TxResponse, WasmQuerier,
+};
 
 // Mock for testing
 pub use crate::mock::Mock;

--- a/packages/cw-orch-core/src/contract/deploy.rs
+++ b/packages/cw-orch-core/src/contract/deploy.rs
@@ -92,13 +92,12 @@ pub trait Deploy<Chain: CwEnv>: Sized {
         let hash_networks: HashMap<String, (Chain, Self::DeployData)> = networks
             .iter()
             .map(|(c, d)| {
-                Ok::<_, <Chain as QueryHandler>::Error>((
-                    QueryHandler::block_info(c)?.chain_id,
+                Ok::<_, CwEnvError>((
+                    QueryHandler::block_info(c).map_err(Into::into)?.chain_id,
                     (c.clone(), d.clone()),
                 ))
             })
-            .collect::<Result<HashMap<_, _>, _>>()
-            .map_err(Into::into)?;
+            .collect::<Result<HashMap<_, _>, _>>()?;
 
         // First we check the deployment status. Which chains have been un-succesfully deployed since last time
         let chains_to_deploy = if let Ok(deployment_left) = read_deployment() {

--- a/packages/cw-orch-core/src/contract/deploy.rs
+++ b/packages/cw-orch-core/src/contract/deploy.rs
@@ -13,8 +13,8 @@ use std::io::BufReader;
 use std::path::PathBuf;
 
 use crate::env::CwOrchEnvVars;
-use crate::environment::queriers::QueryHandler;
 use crate::environment::CwEnv;
+use crate::environment::QueryHandler;
 use crate::CwEnvError;
 
 use super::interface_traits::ContractInstance;

--- a/packages/cw-orch-core/src/contract/interface_traits.rs
+++ b/packages/cw-orch-core/src/contract/interface_traits.rs
@@ -1,6 +1,6 @@
 use super::{Contract, WasmPath};
 use crate::{
-    environment::{queriers::wasm::WasmQuerier, CwEnv, QueryHandler, TxHandler, TxResponse},
+    environment::{CwEnv, QueryHandler, TxHandler, TxResponse, WasmQuerier},
     error::CwEnvError,
     log::contract_target,
 };

--- a/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
+++ b/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
@@ -146,7 +146,10 @@ mod tests {
             _admin: Option<&Addr>,
             _coins: &[cosmwasm_std::Coin],
         ) -> Result<Self::Response, Self::Error> {
-            unimplemented!()
+            Ok(AppResponse {
+                events: vec![],
+                data: None,
+            })
         }
 
         fn execute<E: Serialize + Debug>(
@@ -175,7 +178,7 @@ mod tests {
 
     #[test]
     fn tx_handler_error_usable_on_anyhow() -> anyhow::Result<()> {
-        let _ = associated_error(MockHandler {});
+        associated_error(MockHandler {})?;
         Ok(())
     }
 }

--- a/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
+++ b/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn tx_handler_error_usable_on_anyhow() -> anyhow::Result<()> {
-        associated_error(MockHandler {}).unwrap();
+        let _ = associated_error(MockHandler {});
         Ok(())
     }
 }

--- a/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
+++ b/packages/cw-orch-core/src/environment/cosmwasm_environment.rs
@@ -166,15 +166,4 @@ mod tests {
             unimplemented!()
         }
     }
-
-    fn associated_error<T: TxHandler>(t: T) -> anyhow::Result<()> {
-        t.wait_blocks(5)?;
-        Ok(())
-    }
-
-    #[test]
-    fn tx_handler_error_usable_on_anyhow() -> anyhow::Result<()> {
-        associated_error(MockHandler {})?;
-        Ok(())
-    }
 }

--- a/packages/cw-orch-core/src/environment/mod.rs
+++ b/packages/cw-orch-core/src/environment/mod.rs
@@ -1,13 +1,17 @@
 mod cosmwasm_environment;
 mod index_response;
 mod mut_env;
-pub mod queriers;
+mod queriers;
 mod state;
 
-pub use cosmwasm_environment::{
-    BankQuerier, CwEnv, EnvironmentInfo, EnvironmentQuerier, TxHandler, TxResponse, WasmCodeQuerier,
-};
+pub use cosmwasm_environment::{CwEnv, TxHandler, TxResponse};
 pub use index_response::IndexResponse;
 pub use mut_env::{BankSetter, MutCwEnv};
-pub use queriers::QueryHandler;
-pub use state::{ChainState, DeployDetails, StateInterface};
+pub use queriers::{
+    bank::BankQuerier,
+    env::{EnvironmentInfo, EnvironmentQuerier},
+    node::NodeQuerier,
+    wasm::WasmQuerier,
+    DefaultQueriers, Querier, QuerierGetter, QueryHandler,
+};
+pub use state::{ChainState, StateInterface};

--- a/packages/cw-orch-core/src/environment/mut_env.rs
+++ b/packages/cw-orch-core/src/environment/mut_env.rs
@@ -2,7 +2,7 @@
 //! This allows to set balance and the block for instance
 
 use super::{
-    queriers::bank::{BankQuerier, BankQuerierGetter},
+    queriers::{bank::{BankQuerier}, QuerierGetter},
     CwEnv, TxHandler,
 };
 use cosmwasm_std::Coin;
@@ -10,7 +10,9 @@ use cw_utils::NativeBalance;
 
 pub trait MutCwEnv: BankSetter + CwEnv {}
 
-pub trait BankSetter: TxHandler + BankQuerierGetter<Self::Error> {
+pub trait BankSetter: TxHandler + QuerierGetter<Self::T> {
+    type T: BankQuerier<Error = Self::Error>;
+
     fn set_balance(
         &mut self,
         address: impl Into<String>,
@@ -24,7 +26,7 @@ pub trait BankSetter: TxHandler + BankQuerierGetter<Self::Error> {
     ) -> Result<(), <Self as TxHandler>::Error> {
         let address = address.into();
         // Query the current balance of the account
-        let current_balance = self.bank_querier().balance(address.clone(), None)?;
+        let current_balance = QuerierGetter::<Self::T>::querier(self).balance(address.clone(), None)?;
         let future_balance = NativeBalance(current_balance) + NativeBalance(amount);
         // Set the balance with more funds
         self.set_balance(address, future_balance.into_vec())?;

--- a/packages/cw-orch-core/src/environment/mut_env.rs
+++ b/packages/cw-orch-core/src/environment/mut_env.rs
@@ -2,13 +2,15 @@
 //! This allows to set balance and the block for instance
 
 use super::{
-    queriers::{bank::{BankQuerier}, QuerierGetter},
+    queriers::{bank::BankQuerier, QuerierGetter},
     CwEnv, TxHandler,
 };
 use cosmwasm_std::Coin;
 use cw_utils::NativeBalance;
 
 pub trait MutCwEnv: BankSetter + CwEnv {}
+
+impl<T> MutCwEnv for T where T: BankSetter + CwEnv {}
 
 pub trait BankSetter: TxHandler + QuerierGetter<Self::T> {
     type T: BankQuerier<Error = Self::Error>;
@@ -26,12 +28,11 @@ pub trait BankSetter: TxHandler + QuerierGetter<Self::T> {
     ) -> Result<(), <Self as TxHandler>::Error> {
         let address = address.into();
         // Query the current balance of the account
-        let current_balance = QuerierGetter::<Self::T>::querier(self).balance(address.clone(), None)?;
+        let current_balance =
+            QuerierGetter::<Self::T>::querier(self).balance(address.clone(), None)?;
         let future_balance = NativeBalance(current_balance) + NativeBalance(amount);
         // Set the balance with more funds
         self.set_balance(address, future_balance.into_vec())?;
         Ok(())
     }
 }
-
-impl<T> MutCwEnv for T where T: BankSetter + CwEnv {}

--- a/packages/cw-orch-core/src/environment/queriers/bank.rs
+++ b/packages/cw-orch-core/src/environment/queriers/bank.rs
@@ -1,14 +1,8 @@
 use cosmwasm_std::Coin;
 
-use crate::CwEnvError;
-use std::fmt::Debug;
+use super::Querier;
 
-pub trait BankQuerierGetter<E> {
-    type Querier: BankQuerier<Error = E>;
-    fn bank_querier(&self) -> Self::Querier;
-}
-pub trait BankQuerier {
-    type Error: Into<CwEnvError> + Debug;
+pub trait BankQuerier: Querier {
     /// Query the bank balance of a given address
     /// If denom is None, returns all balances
     fn balance(

--- a/packages/cw-orch-core/src/environment/queriers/env.rs
+++ b/packages/cw-orch-core/src/environment/queriers/env.rs
@@ -1,0 +1,11 @@
+#[derive(Clone)]
+pub struct EnvironmentInfo {
+    pub chain_id: String,
+    pub chain_name: String,
+    pub deployment_id: String,
+}
+
+pub trait EnvironmentQuerier {
+    /// Get some details about the environment.
+    fn env_info(&self) -> EnvironmentInfo;
+}

--- a/packages/cw-orch-core/src/environment/queriers/mod.rs
+++ b/packages/cw-orch-core/src/environment/queriers/mod.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{Addr, BlockInfo};
 use serde::{de::DeserializeOwned, Serialize};
 
-use self::{bank::BankQuerierGetter, node::NodeQuerierGetter, wasm::WasmQuerierGetter};
+use self::{bank::{BankQuerier}, node::{NodeQuerier}, wasm::{WasmQuerier}};
 use crate::CwEnvError;
 use std::fmt::Debug;
 
@@ -11,7 +11,7 @@ pub mod wasm;
 
 /// This trait regroups all querier traits + adds high level interfaces to access some elements faster
 pub trait QueryHandler:
-    NodeQuerierGetter<Self::Error> + BankQuerierGetter<Self::Error> + WasmQuerierGetter<Self::Error>
+    DefaultQueriers
 {
     type Error: Into<CwEnvError> + Debug;
 
@@ -33,4 +33,31 @@ pub trait QueryHandler:
         query_msg: &Q,
         contract_address: &Addr,
     ) -> Result<T, Self::Error>;
+}
+
+
+pub trait QuerierGetter<Q: Querier> {
+    fn querier(&self) -> Q;
+}
+
+pub trait Querier {
+    type Error: Into<CwEnvError> + Debug;
+}
+
+pub trait DefaultQueriers: QuerierGetter<Self::B> + QuerierGetter<Self::W> + QuerierGetter<Self::N> {
+    type B: BankQuerier;
+    type W: WasmQuerier;
+    type N: NodeQuerier;
+
+    fn bank_querier(&self) -> Self::B {
+        self.querier()
+    }
+
+    fn wasm_querier(&self) -> Self::W {
+        self.querier()
+    }
+
+    fn node_querier(&self) -> Self::N {
+        self.querier()
+    }
 }

--- a/packages/cw-orch-core/src/environment/queriers/mod.rs
+++ b/packages/cw-orch-core/src/environment/queriers/mod.rs
@@ -1,18 +1,18 @@
 use cosmwasm_std::{Addr, BlockInfo};
 use serde::{de::DeserializeOwned, Serialize};
 
-use self::{bank::{BankQuerier}, node::{NodeQuerier}, wasm::{WasmQuerier}};
+use self::{bank::BankQuerier, env::EnvironmentQuerier, node::NodeQuerier, wasm::WasmQuerier};
 use crate::CwEnvError;
 use std::fmt::Debug;
 
 pub mod bank;
+pub mod env;
 pub mod node;
 pub mod wasm;
 
-/// This trait regroups all querier traits + adds high level interfaces to access some elements faster
-pub trait QueryHandler:
-    DefaultQueriers
-{
+/// This trait acts as the high-level trait bound for supported queries on a `CwEnv` environment.
+/// It also implements some high-level functionality to make it easy to access.
+pub trait QueryHandler: DefaultQueriers {
     type Error: Into<CwEnvError> + Debug;
 
     /// Wait for an amount of blocks.
@@ -35,7 +35,6 @@ pub trait QueryHandler:
     ) -> Result<T, Self::Error>;
 }
 
-
 pub trait QuerierGetter<Q: Querier> {
     fn querier(&self) -> Q;
 }
@@ -44,7 +43,9 @@ pub trait Querier {
     type Error: Into<CwEnvError> + Debug;
 }
 
-pub trait DefaultQueriers: QuerierGetter<Self::B> + QuerierGetter<Self::W> + QuerierGetter<Self::N> {
+pub trait DefaultQueriers:
+    QuerierGetter<Self::B> + QuerierGetter<Self::W> + QuerierGetter<Self::N> + EnvironmentQuerier
+{
     type B: BankQuerier;
     type W: WasmQuerier;
     type N: NodeQuerier;

--- a/packages/cw-orch-core/src/environment/queriers/mod.rs
+++ b/packages/cw-orch-core/src/environment/queriers/mod.rs
@@ -25,14 +25,18 @@ pub trait QueryHandler: DefaultQueriers {
     fn next_block(&self) -> Result<(), Self::Error>;
 
     /// Return current block info see [`BlockInfo`].
-    fn block_info(&self) -> Result<BlockInfo, Self::Error>;
+    fn block_info(&self) -> Result<BlockInfo, <Self::N as Querier>::Error> {
+        self.node_querier().latest_block()
+    }
 
     /// Send a QueryMsg to a contract.
     fn query<Q: Serialize + Debug, T: Serialize + DeserializeOwned>(
         &self,
         query_msg: &Q,
         contract_address: &Addr,
-    ) -> Result<T, Self::Error>;
+    ) -> Result<T, <Self::W as Querier>::Error> {
+        self.wasm_querier().smart_query(contract_address, query_msg)
+    }
 }
 
 pub trait QuerierGetter<Q: Querier> {

--- a/packages/cw-orch-core/src/environment/queriers/node.rs
+++ b/packages/cw-orch-core/src/environment/queriers/node.rs
@@ -3,12 +3,13 @@ use cosmwasm_std::BlockInfo;
 use crate::{environment::IndexResponse, CwEnvError};
 use std::fmt::Debug;
 
+use super::Querier;
+
 pub trait NodeQuerierGetter<E> {
     type Querier: NodeQuerier<Error = E>;
     fn node_querier(&self) -> Self::Querier;
 }
-pub trait NodeQuerier {
-    type Error: Into<CwEnvError> + Debug;
+pub trait NodeQuerier: Querier {
     type Response: IndexResponse + Debug + Send + Clone;
 
     /// Returns latests block information

--- a/packages/cw-orch-core/src/environment/queriers/node.rs
+++ b/packages/cw-orch-core/src/environment/queriers/node.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::BlockInfo;
 
-use crate::{environment::IndexResponse, CwEnvError};
+use crate::environment::IndexResponse;
 use std::fmt::Debug;
 
 use super::Querier;

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -8,14 +8,13 @@ use crate::{
 };
 use std::fmt::Debug;
 
-use super::QueryHandler;
+use super::{Querier, QueryHandler};
 
 pub trait WasmQuerierGetter<E> {
     type Querier: WasmQuerier<Error = E>;
     fn wasm_querier(&self) -> Self::Querier;
 }
-pub trait WasmQuerier {
-    type Error: Into<CwEnvError> + Debug;
+pub trait WasmQuerier: Querier {
     fn code_id_hash(&self, code_id: u64) -> Result<String, Self::Error>;
 
     /// Query contract info

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -23,16 +23,16 @@ pub trait WasmQuerier: Querier {
     ) -> Result<ContractInfoResponse, Self::Error>;
 
     /// Query contract state
-    fn contract_raw_state(
+    fn raw_query(
         &self,
         address: impl Into<String>,
-        query_data: Vec<u8>,
+        query_keys: Vec<u8>,
     ) -> Result<Vec<u8>, Self::Error>;
 
-    fn contract_smart_state<Q: Serialize, T: DeserializeOwned>(
+    fn smart_query<Q: Serialize, T: DeserializeOwned>(
         &self,
         address: impl Into<String>,
-        query_data: &Q,
+        query_msg: &Q,
     ) -> Result<T, Self::Error>;
 
     /// Query code

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -6,7 +6,6 @@ use crate::{
     environment::TxHandler,
     CwEnvError,
 };
-use std::fmt::Debug;
 
 use super::{Querier, QueryHandler};
 

--- a/packages/cw-orch-core/src/environment/state.rs
+++ b/packages/cw-orch-core/src/environment/state.rs
@@ -34,16 +34,6 @@ pub trait StateInterface: Clone {
     fn get_all_code_ids(&self) -> Result<HashMap<String, u64>, CwEnvError>;
 }
 
-/// Details about the chain and env you are deploying on
-pub struct DeployDetails {
-    /// E.g. juno-2
-    pub chain_id: String,
-    /// E.g. juno
-    pub chain_name: String,
-    /// E.g. default
-    pub deployment_id: String,
-}
-
 impl<S: StateInterface> StateInterface for Rc<RefCell<S>> {
     fn get_address(&self, contract_id: &str) -> Result<Addr, CwEnvError> {
         (**self).borrow().get_address(contract_id)

--- a/packages/cw-orch-mock/src/core.rs
+++ b/packages/cw-orch-mock/src/core.rs
@@ -15,11 +15,12 @@ use cw_orch_core::{
     contract::interface_traits::Uploadable,
     environment::TxHandler,
     environment::{
-        queriers::bank::{BankQuerier},
-        BankSetter, ChainState, IndexResponse, StateInterface,
+        BankQuerier, BankSetter, ChainState, DefaultQueriers, IndexResponse, StateInterface,
     },
     CwEnvError,
 };
+
+use crate::queriers::bank::MockBankQuerier;
 
 use super::state::MockState;
 
@@ -318,6 +319,8 @@ impl<S: StateInterface> TxHandler for Mock<S> {
 }
 
 impl<S: StateInterface> BankSetter for Mock<S> {
+    type T = MockBankQuerier;
+
     fn set_balance(
         &mut self,
         address: impl Into<String>,

--- a/packages/cw-orch-mock/src/queriers/bank.rs
+++ b/packages/cw-orch-mock/src/queriers/bank.rs
@@ -4,8 +4,7 @@ use cosmwasm_std::{Coin, Empty};
 use cw_multi_test::BasicApp;
 use cw_orch_core::{
     environment::{
-        queriers::{bank::{BankQuerier}, Querier},
-        StateInterface, TxHandler,
+        QuerierGetter, StateInterface, {BankQuerier, Querier},
     },
     CwEnvError,
 };
@@ -24,10 +23,8 @@ impl MockBankQuerier {
     }
 }
 
-impl<S: StateInterface> BankQuerierGetter<<Self as TxHandler>::Error> for Mock<S> {
-    type Querier = MockBankQuerier;
-
-    fn bank_querier(&self) -> Self::Querier {
+impl<S: StateInterface> QuerierGetter<MockBankQuerier> for Mock<S> {
+    fn querier(&self) -> MockBankQuerier {
         MockBankQuerier::new(self)
     }
 }

--- a/packages/cw-orch-mock/src/queriers/bank.rs
+++ b/packages/cw-orch-mock/src/queriers/bank.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Coin, Empty};
 use cw_multi_test::BasicApp;
 use cw_orch_core::{
     environment::{
-        queriers::bank::{BankQuerier, BankQuerierGetter},
+        queriers::{bank::{BankQuerier}, Querier},
         StateInterface, TxHandler,
     },
     CwEnvError,
@@ -32,9 +32,11 @@ impl<S: StateInterface> BankQuerierGetter<<Self as TxHandler>::Error> for Mock<S
     }
 }
 
-impl BankQuerier for MockBankQuerier {
+impl Querier for MockBankQuerier {
     type Error = CwEnvError;
+}
 
+impl BankQuerier for MockBankQuerier {
     fn balance(
         &self,
         address: impl Into<String>,

--- a/packages/cw-orch-mock/src/queriers/env.rs
+++ b/packages/cw-orch-mock/src/queriers/env.rs
@@ -1,0 +1,18 @@
+use cw_orch_core::environment::{
+    EnvironmentInfo, EnvironmentQuerier, QueryHandler, StateInterface,
+};
+
+use crate::Mock;
+
+impl<S: StateInterface> EnvironmentQuerier for Mock<S> {
+    fn env_info(&self) -> EnvironmentInfo {
+        let block_info = self.block_info().unwrap();
+        let chain_id = block_info.chain_id.clone();
+        let chain_name = chain_id.rsplitn(2, '-').collect::<Vec<_>>()[1].to_string();
+        EnvironmentInfo {
+            chain_id,
+            chain_name,
+            deployment_id: "default".to_string(),
+        }
+    }
+}

--- a/packages/cw-orch-mock/src/queriers/mod.rs
+++ b/packages/cw-orch-mock/src/queriers/mod.rs
@@ -36,21 +36,6 @@ impl<S: StateInterface> QueryHandler for Mock<S> {
         self.app.borrow_mut().update_block(next_block);
         Ok(())
     }
-
-    fn block_info(&self) -> Result<cosmwasm_std::BlockInfo, CwEnvError> {
-        Ok(self.app.borrow().block_info())
-    }
-    fn query<Q: Serialize + Debug, T: Serialize + DeserializeOwned>(
-        &self,
-        query_msg: &Q,
-        contract_address: &Addr,
-    ) -> Result<T, CwEnvError> {
-        self.app
-            .borrow()
-            .wrap()
-            .query_wasm_smart(contract_address, query_msg)
-            .map_err(From::from)
-    }
 }
 
 impl<S: StateInterface> DefaultQueriers for Mock<S> {

--- a/packages/cw-orch-mock/src/queriers/mod.rs
+++ b/packages/cw-orch-mock/src/queriers/mod.rs
@@ -2,13 +2,14 @@ use crate::Mock;
 use cosmwasm_std::Addr;
 use cw_multi_test::next_block;
 use cw_orch_core::{
-    environment::{queriers::QueryHandler, StateInterface},
+    environment::{DefaultQueriers, QueryHandler, StateInterface},
     CwEnvError,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 pub mod bank;
+pub mod env;
 pub mod node;
 pub mod wasm;
 
@@ -50,4 +51,10 @@ impl<S: StateInterface> QueryHandler for Mock<S> {
             .query_wasm_smart(contract_address, query_msg)
             .map_err(From::from)
     }
+}
+
+impl<S: StateInterface> DefaultQueriers for Mock<S> {
+    type B = bank::MockBankQuerier;
+    type W = wasm::MockWasmQuerier;
+    type N = node::MockNodeQuerier;
 }

--- a/packages/cw-orch-mock/src/queriers/mod.rs
+++ b/packages/cw-orch-mock/src/queriers/mod.rs
@@ -1,12 +1,10 @@
 use crate::Mock;
-use cosmwasm_std::Addr;
+
 use cw_multi_test::next_block;
 use cw_orch_core::{
     environment::{DefaultQueriers, QueryHandler, StateInterface},
     CwEnvError,
 };
-use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
 
 pub mod bank;
 mod env;

--- a/packages/cw-orch-mock/src/queriers/node.rs
+++ b/packages/cw-orch-mock/src/queriers/node.rs
@@ -3,10 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use cosmwasm_std::Empty;
 use cw_multi_test::{AppResponse, BasicApp};
 use cw_orch_core::{
-    environment::{
-        queriers::node::{NodeQuerier, NodeQuerierGetter},
-        StateInterface, TxHandler,
-    },
+    environment::{NodeQuerier, Querier, QuerierGetter, StateInterface},
     CwEnvError,
 };
 
@@ -24,17 +21,18 @@ impl MockNodeQuerier {
     }
 }
 
-impl<S: StateInterface> NodeQuerierGetter<<Self as TxHandler>::Error> for Mock<S> {
-    type Querier = MockNodeQuerier;
+impl Querier for MockNodeQuerier {
+    type Error = CwEnvError;
+}
 
-    fn node_querier(&self) -> Self::Querier {
+impl<S: StateInterface> QuerierGetter<MockNodeQuerier> for Mock<S> {
+    fn querier(&self) -> MockNodeQuerier {
         MockNodeQuerier::new(self)
     }
 }
 
 impl NodeQuerier for MockNodeQuerier {
     type Response = AppResponse;
-    type Error = CwEnvError;
 
     fn latest_block(&self) -> Result<cosmwasm_std::BlockInfo, Self::Error> {
         Ok(self.app.borrow().block_info())

--- a/packages/cw-orch-mock/src/queriers/wasm.rs
+++ b/packages/cw-orch-mock/src/queriers/wasm.rs
@@ -4,10 +4,7 @@ use cosmwasm_std::{to_json_binary, ContractInfoResponse, Empty};
 use cw_multi_test::BasicApp;
 use cw_orch_core::{
     contract::interface_traits::{ContractInstance, Uploadable},
-    environment::{
-        queriers::wasm::{WasmQuerier, WasmQuerierGetter},
-        QueryHandler, StateInterface, TxHandler,
-    },
+    environment::{Querier, QuerierGetter, QueryHandler, StateInterface, TxHandler, WasmQuerier},
     CwEnvError,
 };
 use serde::{de::DeserializeOwned, Serialize};
@@ -26,16 +23,17 @@ impl MockWasmQuerier {
     }
 }
 
-impl<S: StateInterface> WasmQuerierGetter<<Self as TxHandler>::Error> for Mock<S> {
-    type Querier = MockWasmQuerier;
+impl Querier for MockWasmQuerier {
+    type Error = CwEnvError;
+}
 
-    fn wasm_querier(&self) -> Self::Querier {
+impl<S: StateInterface> QuerierGetter<MockWasmQuerier> for Mock<S> {
+    fn querier(&self) -> MockWasmQuerier {
         MockWasmQuerier::new(self)
     }
 }
-impl WasmQuerier for MockWasmQuerier {
-    type Error = CwEnvError;
 
+impl WasmQuerier for MockWasmQuerier {
     fn code_id_hash(&self, code_id: u64) -> Result<String, CwEnvError> {
         let code_info = self.app.borrow().wrap().query_wasm_code_info(code_id)?;
         Ok(code_info.checksum.to_string())

--- a/packages/cw-orch-mock/src/queriers/wasm.rs
+++ b/packages/cw-orch-mock/src/queriers/wasm.rs
@@ -57,7 +57,7 @@ impl WasmQuerier for MockWasmQuerier {
         Ok(sha256::digest(contract.id().as_bytes()))
     }
 
-    fn contract_raw_state(
+    fn raw_query(
         &self,
         address: impl Into<String>,
         query_data: Vec<u8>,
@@ -74,7 +74,7 @@ impl WasmQuerier for MockWasmQuerier {
             ))?)
     }
 
-    fn contract_smart_state<Q, T>(
+    fn smart_query<Q, T>(
         &self,
         address: impl Into<String>,
         query_data: &Q,


### PR DESCRIPTION
This draft PR shows a different approach to querier construction and access. 

Instead of having a `Getter` trait for each querier we have a single `QuerierGetter` trait that retrieves a querier `Q`. This querier `Q` implements a `Querier` trait. Both are shown below: 

```rust
pub trait QuerierGetter<Q: Querier> {
    fn querier(&self) -> Q;
}

pub trait Querier {
    type Error: Into<CwEnvError> + Debug;
}
```

The inclusion of `type Error` in `Querier` prevents some duplicate code in the traits. 

Now each querier trait needs to add `Querier` as its trait bound, like so: 

```rust
pub trait BankQuerier: Querier {
    fn supply_of(&self, denom: impl Into<String>) -> Result<Coin, Self::Error>;
    // ...
}
```

To get allow for retrieving the querier we implement the `QuerierGetter` with a specified querier like so: 

```rust
impl Querier for DaemonBankQuerier {
    type Error = DaemonError;
}

impl QuerierGetter<DaemonBankQuerier> for Daemon {
    fn querier(&self) -> DaemonBankQuerier {
        DaemonBankQuerier::new(self)
    }
}
```

We can then create arbitrary sets of supported queriers, like: 

```rust
pub trait DefaultQueriers: QuerierGetter<Self::B> + QuerierGetter<Self::W> + QuerierGetter<Self::N> {
    type B: BankQuerier;
    type W: WasmQuerier;
    type N: NodeQuerier;

    fn bank_querier(&self) -> Self::B {
        self.querier()
    }

    fn wasm_querier(&self) -> Self::W {
        self.querier()
    }

    fn node_querier(&self) -> Self::N {
        self.querier()
    }
}
```

And use that as a trait-bound! 

```rust
pub trait QueryHandler: DefaultQueriers {
  // ...
}
```


Thoughts?