### PR TITLE
Use hexbinary as checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cw-orch-fns-derive = { path = "packages/cw-orch-fns-derive", version = "0.18.0" 
 cw-orch-networks = { path = "packages/cw-orch-networks", version = "0.20.0" }
 
 thiserror = { version = "1.0.21" }
-sha256 = { version = "1" }
+sha2 = { version = "0.10.8" }
 serde_json = "1.0.79"
 tonic = { version = "0.10.2" }
 prost-types = "0.12.3"

--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = { workspace = true }
 
 prost-types = { workspace = true }
 # Daemon deps
-sha256 = { workspace = true }
+sha2 = { workspace = true }
 prost = { version = "0.12.3" }
 bitcoin = { version = "0.30.0" }
 hex = { version = "0.4.3" }

--- a/cw-orch-daemon/src/queriers/cosmwasm.rs
+++ b/cw-orch-daemon/src/queriers/cosmwasm.rs
@@ -51,7 +51,7 @@ impl CosmWasm {
         let request = QueryCodeRequest { code_id };
         let resp = client.code(request).await?.into_inner();
         let contract_hash = resp.code_info.unwrap().data_hash;
-        Ok(HexBinary::from(contract_hash))
+        Ok(contract_hash.into())
     }
 
     /// Query contract info

--- a/cw-orch-daemon/src/queriers/cosmwasm.rs
+++ b/cw-orch-daemon/src/queriers/cosmwasm.rs
@@ -5,7 +5,7 @@ use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmrs::AccountId;
 use cosmwasm_std::{
     from_json, instantiate2_address, to_json_binary, CanonicalAddr, CodeInfoResponse,
-    ContractInfoResponse,
+    ContractInfoResponse, HexBinary,
 };
 use cw_orch_core::environment::{Querier, QuerierGetter, WasmQuerier};
 use tokio::runtime::Handle;
@@ -45,14 +45,13 @@ impl Querier for CosmWasm {
 
 impl CosmWasm {
     /// Query code_id by hash
-    pub async fn _code_id_hash(&self, code_id: u64) -> Result<String, DaemonError> {
+    pub async fn _code_id_hash(&self, code_id: u64) -> Result<HexBinary, DaemonError> {
         use cosmos_modules::cosmwasm::{query_client::*, QueryCodeRequest};
         let mut client: QueryClient<Channel> = QueryClient::new(self.channel.clone());
         let request = QueryCodeRequest { code_id };
         let resp = client.code(request).await?.into_inner();
         let contract_hash = resp.code_info.unwrap().data_hash;
-        let on_chain_hash = base16::encode_lower(&contract_hash);
-        Ok(on_chain_hash)
+        Ok(HexBinary::from(contract_hash))
     }
 
     /// Query contract info
@@ -199,7 +198,7 @@ impl CosmWasm {
 }
 
 impl WasmQuerier for CosmWasm {
-    fn code_id_hash(&self, code_id: u64) -> Result<String, Self::Error> {
+    fn code_id_hash(&self, code_id: u64) -> Result<HexBinary, Self::Error> {
         self.rt_handle
             .as_ref()
             .ok_or(DaemonError::QuerierNeedRuntime)?
@@ -287,7 +286,7 @@ impl WasmQuerier for CosmWasm {
         let prefix = account_id.prefix();
         let canon = account_id.to_bytes();
         let checksum = self.code_id_hash(code_id)?;
-        let addr = instantiate2_address(checksum.as_bytes(), &CanonicalAddr(canon.into()), &salt)?;
+        let addr = instantiate2_address(checksum.as_slice(), &CanonicalAddr(canon.into()), &salt)?;
 
         Ok(AccountId::new(prefix, &addr.0)?.to_string())
     }

--- a/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
+++ b/cw-orch/src/osmosis_test_tube/queriers/wasm.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc, str::FromStr};
 use cosmrs::AccountId;
 use cosmwasm_std::{
     from_json, instantiate2_address, to_json_vec, CanonicalAddr, CodeInfoResponse,
-    ContractInfoResponse,
+    ContractInfoResponse, HexBinary,
 };
 use cw_orch_core::{
     environment::{Querier, QuerierGetter, StateInterface, WasmQuerier},
@@ -41,7 +41,7 @@ impl<S: StateInterface> QuerierGetter<OsmosisTestTubeWasmQuerier> for OsmosisTes
 }
 
 impl WasmQuerier for OsmosisTestTubeWasmQuerier {
-    fn code_id_hash(&self, code_id: u64) -> Result<String, Self::Error> {
+    fn code_id_hash(&self, code_id: u64) -> Result<HexBinary, Self::Error> {
         let code_info_result: QueryCodeResponse = self
             .app
             .borrow()
@@ -51,12 +51,11 @@ impl WasmQuerier for OsmosisTestTubeWasmQuerier {
             )
             .map_err(map_err)?;
 
-        Ok(hex::encode(
-            code_info_result
-                .code_info
-                .ok_or(CwEnvError::CodeIdNotInStore(code_id.to_string()))?
-                .data_hash,
-        ))
+        Ok(code_info_result
+            .code_info
+            .ok_or(CwEnvError::CodeIdNotInStore(code_id.to_string()))?
+            .data_hash
+            .into())
     }
 
     fn contract_info(
@@ -170,7 +169,7 @@ impl WasmQuerier for OsmosisTestTubeWasmQuerier {
         let prefix = account_id.prefix();
         let canon = account_id.to_bytes();
         let addr =
-            instantiate2_address(checksum.as_bytes(), &CanonicalAddr(canon.into()), &salt).unwrap();
+            instantiate2_address(checksum.as_slice(), &CanonicalAddr(canon.into()), &salt).unwrap();
 
         Ok(AccountId::new(prefix, &addr.0).unwrap().to_string())
     }

--- a/packages/cw-orch-core/Cargo.toml
+++ b/packages/cw-orch-core/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true }
 cw-multi-test = { workspace = true }
 
 log = { workspace = true }
-sha256 = { workspace = true }
+sha2 = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 

--- a/packages/cw-orch-core/src/contract/paths.rs
+++ b/packages/cw-orch-core/src/contract/paths.rs
@@ -56,7 +56,7 @@ mod wasm_path {
             let mut wasm = Vec::<u8>::new();
             file.read_to_end(&mut wasm)?;
             let checksum: [u8; 32] = Sha256::digest(wasm).into();
-            Ok(HexBinary::from(checksum))
+            Ok(checksum.into())
         }
     }
 }

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{CodeInfoResponse, ContractInfoResponse};
+use cosmwasm_std::{CodeInfoResponse, ContractInfoResponse, HexBinary};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
 use super::{Querier, QueryHandler};
 
 pub trait WasmQuerier: Querier {
-    fn code_id_hash(&self, code_id: u64) -> Result<String, Self::Error>;
+    fn code_id_hash(&self, code_id: u64) -> Result<HexBinary, Self::Error>;
 
     /// Query contract info
     fn contract_info(
@@ -37,7 +37,7 @@ pub trait WasmQuerier: Querier {
     /// Returns the checksum of the WASM file if the env supports it. Will re-upload every time if not supported.
     fn local_hash<Chain: TxHandler + QueryHandler, T: Uploadable + ContractInstance<Chain>>(
         contract: &T,
-    ) -> Result<String, CwEnvError> {
+    ) -> Result<HexBinary, CwEnvError> {
         contract.wasm().checksum()
     }
 

--- a/packages/cw-orch-mock/Cargo.toml
+++ b/packages/cw-orch-mock/Cargo.toml
@@ -15,7 +15,7 @@ cosmwasm-std = { workspace = true }
 cw-multi-test = { workspace = true }
 cw-utils = { workspace = true }
 serde = { workspace = true }
-sha256 = { workspace = true }
+sha2 = { workspace = true }
 log.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
This PR aims to return `cosmwasm_std::HexBinary` instead of hex encoded String, for checksums