### PR TITLE
Fix wrong default state file

### DIFF
--- a/packages/cw-orch-core/src/env.rs
+++ b/packages/cw-orch-core/src/env.rs
@@ -119,7 +119,7 @@ pub fn default_state_folder() -> Result<PathBuf, StdError> {
 impl Default for CwOrchEnvVars {
     fn default() -> Self {
         CwOrchEnvVars {
-            state_file: default_state_folder().unwrap().join("state.json"),
+            state_file: PathBuf::from_str("state.json").unwrap(),
             artifacts_dir: None,
             gas_buffer: None,
             min_gas: None,


### PR DESCRIPTION
Fixes ORC-79. 
Default `state_file` have absolute path, instead of relative. But we only create `~/.cw-orchestrator` dir if path is relative:
https://github.com/AbstractSDK/cw-orchestrator/blob/0f57bf06a740b68d19c60a19ddbce94f2ca857e0/cw-orch-daemon/src/state.rs#L116-L148

This was tested with on https://github.com/AbstractSDK/savings-app/pull/19