### PR TITLE
removing runtimes

### DIFF
--- a/contracts/counter/examples/deploy.rs
+++ b/contracts/counter/examples/deploy.rs
@@ -2,8 +2,7 @@
 use counter_contract::{
     msg::InstantiateMsg, CounterContract, CounterExecuteMsgFns, CounterQueryMsgFns,
 };
-use cw_orch::{anyhow, prelude::*, tokio};
-use tokio::runtime::Runtime;
+use cw_orch::{anyhow, prelude::*};
 
 const LOCAL_MNEMONIC: &str = "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose";
 pub fn main() -> anyhow::Result<()> {
@@ -12,12 +11,8 @@ pub fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok(); // Used to load the `.env` file if any
     pretty_env_logger::init(); // Used to log contract and chain interactions
 
-    let rt = Runtime::new()?;
     let network = networks::LOCAL_JUNO;
-    let chain = DaemonBuilder::default()
-        .handle(rt.handle())
-        .chain(network)
-        .build()?;
+    let chain = DaemonBuilder::default().chain(network).build()?;
     // ANCHOR_END: chain_construction
 
     // ANCHOR: contract_interaction

--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -66,6 +66,7 @@ async-recursion = "1.0.5"
 
 # Gzip
 flate2 = { version = "1.0.26" }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 cw-orch-daemon = { path = "." }

--- a/cw-orch-daemon/examples/daemon-capabilities.rs
+++ b/cw-orch-daemon/examples/daemon-capabilities.rs
@@ -5,22 +5,18 @@ use cosmwasm_std::coins;
 // ANCHOR: full_counter_example
 use cw_orch_daemon::DaemonBuilder;
 use cw_orch_networks::networks;
-use tokio::runtime::Runtime;
 
 const LOCAL_MNEMONIC: &str = "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose";
 pub fn main() -> anyhow::Result<()> {
     std::env::set_var("LOCAL_MNEMONIC", LOCAL_MNEMONIC);
 
-    let rt = Runtime::new()?;
     let network = networks::LOCAL_JUNO;
-    let daemon = DaemonBuilder::default()
-        .handle(rt.handle())
-        .chain(network)
-        .build()?;
+    let daemon = DaemonBuilder::default().chain(network).build()?;
 
     // We commit the tx (also resimulates the tx)
     // ANCHOR: send_tx
     let wallet = daemon.wallet();
+    let rt = daemon.rt_handle;
     rt.block_on(wallet.bank_send("<address-of-my-sister>", coins(345, "ujunox")))?;
     // ANCHOR_END: send_tx
 

--- a/cw-orch-daemon/src/lib.rs
+++ b/cw-orch-daemon/src/lib.rs
@@ -53,3 +53,7 @@ pub(crate) mod cosmos_modules {
 
 /// Re-export trait and data required to fetch daemon data from chain-registry
 pub use ibc_chain_registry::{chain::ChainData as ChainRegistryData, fetchable::Fetchable};
+
+lazy_static::lazy_static! {
+    pub static ref RUNTIME: tokio::runtime::Runtime = tokio::runtime::Runtime::new().unwrap();
+}

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -99,7 +99,10 @@ impl DaemonBuilder {
 
     /// Build a Daemon
     pub fn build(&self) -> Result<Daemon, DaemonError> {
-        let rt_handle = self.handle.clone().unwrap_or(RUNTIME.handle().clone());
+        let rt_handle = self
+            .handle
+            .clone()
+            .unwrap_or_else(|| RUNTIME.handle().clone());
 
         // build the underlying daemon
         let daemon = rt_handle.block_on(DaemonAsyncBuilder::from(self.clone()).build())?;

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -1,10 +1,10 @@
-use bitcoin::secp256k1::All;
-use ibc_chain_registry::chain::ChainData;
-
+use crate::RUNTIME;
 use crate::{
     sender::{Sender, SenderBuilder, SenderOptions},
     DaemonAsyncBuilder,
 };
+use bitcoin::secp256k1::All;
+use ibc_chain_registry::chain::ChainData;
 
 use super::{super::error::DaemonError, core::Daemon};
 
@@ -23,7 +23,6 @@ use super::{super::error::DaemonError, core::Daemon};
 pub struct DaemonBuilder {
     // # Required
     pub(crate) chain: Option<ChainData>,
-    pub(crate) handle: Option<tokio::runtime::Handle>,
     // # Optional
     pub(crate) deployment_id: Option<String>,
 
@@ -45,24 +44,6 @@ impl DaemonBuilder {
     /// Defaults to `default`
     pub fn deployment_id(&mut self, deployment_id: impl Into<String>) -> &mut Self {
         self.deployment_id = Some(deployment_id.into());
-        self
-    }
-
-    /// Set the tokio runtime handle to use for the Daemon
-    ///
-    /// ## Example
-    /// ```no_run
-    /// use cw_orch_daemon::Daemon;
-    /// use tokio::runtime::Runtime;
-    /// let rt = Runtime::new().unwrap();
-    /// let Daemon = Daemon::builder()
-    ///     .handle(rt.handle())
-    ///     // ...
-    ///     .build()
-    ///     .unwrap();
-    /// ```
-    pub fn handle(&mut self, handle: &tokio::runtime::Handle) -> &mut Self {
-        self.handle = Some(handle.clone());
         self
     }
 
@@ -99,10 +80,7 @@ impl DaemonBuilder {
 
     /// Build a Daemon
     pub fn build(&self) -> Result<Daemon, DaemonError> {
-        let rt_handle = self
-            .handle
-            .clone()
-            .ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
+        let rt_handle = RUNTIME.handle().clone();
         // build the underlying daemon
         let daemon = rt_handle.block_on(DaemonAsyncBuilder::from(self.clone()).build())?;
 

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -29,7 +29,6 @@ use tonic::transport::Channel;
     let rt = Runtime::new().unwrap();
     let daemon: Daemon = Daemon::builder()
         .chain(networks::JUNO_1)
-        .handle(rt.handle())
         .build()
         .unwrap();
     ```
@@ -71,7 +70,6 @@ impl Daemon {
         builder
             .chain(self.state().chain_data.clone())
             .sender((*self.daemon.sender).clone())
-            .handle(&self.rt_handle)
             .deployment_id(&self.state().deployment_id);
         builder
     }

--- a/cw-orch-daemon/tests/daemon_helpers.rs
+++ b/cw-orch-daemon/tests/daemon_helpers.rs
@@ -20,11 +20,8 @@ mod tests {
     fn helper_traits() {
         use cw_orch_networks::networks;
 
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-
         let daemon = Daemon::builder()
             .chain(networks::LOCAL_JUNO)
-            .handle(runtime.handle())
             .build()
             .unwrap();
 
@@ -102,7 +99,6 @@ mod tests {
 
     //     let daemon = Daemon::builder()
     //         .chain(chain)
-    //         .handle(runtime.handle())
     //         .mnemonic("tide genuine angle mass fall promote blind skull swim army maximum add peasant fringe uncle october female crisp voyage blind extend jeans give wrap")
     //         .build()
     //         .unwrap();
@@ -120,11 +116,8 @@ mod tests {
     fn cw_orch_interface_traits() {
         use cw_orch_networks::networks;
 
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-
         let daemon = Daemon::builder()
             .chain(networks::LOCAL_JUNO)
-            .handle(runtime.handle())
             .build()
             .unwrap();
 

--- a/cw-orch-daemon/tests/index.rs
+++ b/cw-orch-daemon/tests/index.rs
@@ -10,17 +10,13 @@ mod tests {
     fn mnemonic_index() -> anyhow::Result<()> {
         use cw_orch_networks::networks;
 
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-
         let daemon = Daemon::builder()
             .chain(networks::LOCAL_JUNO)
-            .handle(runtime.handle())
             .build()
             .unwrap();
 
         let indexed_daemon = Daemon::builder()
             .chain(networks::LOCAL_JUNO)
-            .handle(runtime.handle())
             .hd_index(56)
             .build()
             .unwrap();

--- a/cw-orch-daemon/tests/instantiate2.rs
+++ b/cw-orch-daemon/tests/instantiate2.rs
@@ -14,11 +14,8 @@ pub mod test {
 
     #[test]
     fn instantiate2() -> anyhow::Result<()> {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-
         let app = Daemon::builder()
             .chain(networks::LOCAL_JUNO)
-            .handle(runtime.handle())
             .build()
             .unwrap();
 

--- a/cw-orch-daemon/tests/querier.rs
+++ b/cw-orch-daemon/tests/querier.rs
@@ -219,7 +219,6 @@ mod queriers {
         let cosm_wasm = CosmWasm::new_async(channel);
         let daemon = Daemon::builder()
             .chain(networks::LOCAL_JUNO)
-            .handle(rt.handle())
             .build()
             .unwrap();
 

--- a/cw-orch/examples/complex_testnet_daemon.rs
+++ b/cw-orch/examples/complex_testnet_daemon.rs
@@ -13,7 +13,6 @@ use osmosis_std::types::{
 };
 use prost::Message;
 use prost_types::Any;
-use tokio::runtime::Runtime;
 
 pub const SUBDENOM: &str = "complex-test";
 
@@ -30,15 +29,11 @@ pub fn main() {
     // Remember to set the `RUST_LOG` env variable to be able to see the execution
     env_logger::init();
 
-    // We start by creating a runtime, which is required for a sync daemon.
-    let runtime = Runtime::new().unwrap();
-
     // We can now create a daemon. This daemon will be used to interact with the chain.
     // In the background, the `build` function uses the `TEST_MNEMONIC` variable, don't forget to set it !
     let daemon = Daemon::builder()
         // set the network to use
         .chain(cw_orch::daemon::networks::UNI_6)
-        .handle(runtime.handle())
         .build()
         .unwrap();
 
@@ -106,7 +101,8 @@ pub fn main() {
         .unwrap();
     // We send some funds to the counter contract
     let contract_addr = counter.addr_str().unwrap();
-    runtime
+    daemon
+        .rt_handle
         .block_on(
             daemon
                 .daemon

--- a/cw-orch/examples/injective.rs
+++ b/cw-orch/examples/injective.rs
@@ -7,7 +7,6 @@ use cw_orch::prelude::{
     Daemon, TxHandler,
 };
 
-use tokio::runtime::Runtime;
 const TESTNET_MNEMONIC: &str = "across left ignore gold echo argue track joy hire release captain enforce hotel wide flash hotel brisk joke midnight duck spare drop chronic stool";
 
 pub fn main() {

--- a/cw-orch/examples/injective.rs
+++ b/cw-orch/examples/injective.rs
@@ -15,14 +15,11 @@ pub fn main() {
     // in async code (e.g. tokio), which enables multi-threaded and non-blocking code.
 
     env_logger::init();
-    // We start by creating a runtime, which is required for a sync daemon.
-    let runtime = Runtime::new().unwrap();
 
     // We can now create a daemon. This daemon will be used to interact with the chain.
     let res = Daemon::builder()
         // set the network to use
         .chain(networks::INJECTIVE_888)
-        .handle(runtime.handle())
         .mnemonic(TESTNET_MNEMONIC)
         .build();
 

--- a/cw-orch/examples/local_daemon.rs
+++ b/cw-orch/examples/local_daemon.rs
@@ -6,7 +6,6 @@ use cw_orch::prelude::{
     ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Daemon,
     TxHandler,
 };
-use tokio::runtime::Runtime;
 const LOCAL_MNEMONIC: &str = "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose";
 
 pub fn main() {
@@ -16,14 +15,11 @@ pub fn main() {
     env_logger::init();
 
     // ANCHOR: daemon_creation
-    // We start by creating a runtime, which is required for a sync daemon.
-    let runtime = Runtime::new().unwrap();
 
-    // We can now create a daemon. This daemon will be used to interact with the chain.
+    // We start by creating a daemon. This daemon will be used to interact with the chain.
     let daemon = Daemon::builder()
         // set the network to use
         .chain(cw_orch::daemon::networks::LOCAL_JUNO) // chain parameter
-        .handle(runtime.handle()) // handler parameter
         .build()
         .unwrap();
 

--- a/cw-orch/examples/queries/bank_query.rs
+++ b/cw-orch/examples/queries/bank_query.rs
@@ -3,15 +3,10 @@ use cw_orch::daemon::Daemon;
 use cw_orch::prelude::BankQuerier;
 use cw_orch::prelude::QuerierGetter;
 use cw_orch_daemon::queriers::Bank;
-use tokio::runtime::Runtime;
 pub fn main() {
-    // We start by creating a runtime, which is required for a sync daemon.
-    let runtime = Runtime::new().unwrap();
-
     // We can now create a daemon. This daemon will be used to interact with the chain.
     let daemon = Daemon::builder()
         .chain(cw_orch::daemon::networks::LOCAL_JUNO) // chain parameter
-        .handle(runtime.handle()) // handler parameter
         .build()
         .unwrap();
 

--- a/cw-orch/examples/queries/testnet_queries.rs
+++ b/cw-orch/examples/queries/testnet_queries.rs
@@ -4,17 +4,12 @@ use cw_orch::prelude::BankQuerier;
 use cw_orch::prelude::QuerierGetter;
 use cw_orch_daemon::queriers::Ibc;
 use cw_orch_daemon::queriers::{Bank, Staking};
-use tokio::runtime::Runtime;
 pub const TEST_MNEMONIC: &str="scare silent genuine cheese monitor industry item cloth pet gather cruise long confirm van lunar tomato scrub silk guide eight truly rural remember swim";
 
 pub fn main() -> AnyResult<()> {
-    // We start by creating a runtime, which is required for a sync daemon.
-    let runtime = Runtime::new()?;
-
-    // We can now create a daemon. This daemon will be used to interact with the chain.
+    // We start by creating a daemon. This daemon will be used to interact with the chain.
     let daemon = Daemon::builder()
         .chain(cw_orch::daemon::networks::JUNO_1) // chain parameter
-        .handle(runtime.handle()) // handler parameter
         .mnemonic(TEST_MNEMONIC)
         .build()?;
 
@@ -27,14 +22,18 @@ pub fn main() -> AnyResult<()> {
     // We do an actual Staking query on MAINNET
     let staking_query_client: Staking = daemon.querier();
     let validator = "junovaloper185hgkqs8q8ysnc8cvkgd8j2knnq2m0ah6ae73gntv9ampgwpmrxqlfzywn";
-    let validator_result = runtime.block_on(staking_query_client._validator(validator))?;
+    let validator_result = daemon
+        .rt_handle
+        .block_on(staking_query_client._validator(validator))?;
     println!("Validator info of {} : {:?}", sender, validator_result);
 
     // We do an actual IBC query on MAINNET
     let ibc_query_client: Ibc = daemon.querier();
     let port_id = "transfer";
     let channel_id = "channel-0";
-    let channel_result = runtime.block_on(ibc_query_client._channel(port_id, channel_id))?;
+    let channel_result = daemon
+        .rt_handle
+        .block_on(ibc_query_client._channel(port_id, channel_id))?;
     println!(
         "Channel info of {port_id}:{channel_id} : {:?}",
         channel_result

--- a/cw-orch/examples/testnet_daemon.rs
+++ b/cw-orch/examples/testnet_daemon.rs
@@ -6,7 +6,6 @@ use cw_orch::prelude::{
     ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Daemon,
     TxHandler,
 };
-use tokio::runtime::Runtime;
 
 /// In order to use this script, you need to set the following env variables
 /// RUST_LOG (recommended value `info`) to see the app logs
@@ -21,15 +20,11 @@ pub fn main() {
     // Remember to set the `RUST_LOG` env variable to be able to see the execution
     env_logger::init();
 
-    // We start by creating a runtime, which is required for a sync daemon.
-    let runtime = Runtime::new().unwrap();
-
     // We can now create a daemon. This daemon will be used to interact with the chain.
     // In the background, the `build` function uses the `TEST_MNEMONIC` variable, don't forget to set it !
     let daemon = Daemon::builder()
         // set the network to use
         .chain(cw_orch::daemon::networks::UNI_6)
-        .handle(runtime.handle())
         .build()
         .unwrap();
 

--- a/docs/src/interchain/integrations/daemon.md
+++ b/docs/src/interchain/integrations/daemon.md
@@ -16,7 +16,7 @@ use cw_orch::prelude::networks::{LOCAL_JUNO, LOCAL_OSMO};
 use cw_orch_interchain::interchain::{ChannelCreationValidator,DaemonInterchainEnv};
 # fn main(){
     let rt = Runtime::new()?;
-    let mut interchain = DaemonInterchainEnv::new(rt.handle(), vec![
+    let mut interchain = DaemonInterchainEnv::new(vec![
         (LOCAL_JUNO, None),
         (LOCAL_OSMO, None)
     ], &ChannelCreationValidator)?;
@@ -42,7 +42,6 @@ You can also add daemons manually to the `interchain` object:
 
 ```rust,ignore
 let local_migaloo = DaemonBuilder::default()
-    .handle(rt.handle())
     .chain(LOCAL_MIGALOO)
     .build()?;
 interchain.add_daemons(vec![local_migaloo]);
@@ -59,7 +58,7 @@ use cw_orch_interchain::interchain::{Starship, ChannelCreator};
 
 # fn main(){
     let rt = Runtime::new()?;
-    let starship = Starship::new(rt.handle().clone(), None)?;
+    let starship = Starship::new(None)?;
     let interchain = starship.interchain_env();
 
     let _local_juno: Daemon = interchain.chain("juno-1")?;

--- a/docs/src/interchain/quick-start.md
+++ b/docs/src/interchain/quick-start.md
@@ -200,14 +200,12 @@ let rt = tokio::runtime::Runtime::new().unwrap();
 // We create the daemons ourselves to interact with actual running chains (testnet here)
 let juno = Daemon::builder()
         .chain(cw_orch::daemon::networks::UNI_6)
-        .handle(rt.handle())
         .build()
         .unwrap(); 
 
 // We create the daemons ourselves to interact with actual running chains (testnet here)
 let osmosis = Daemon::builder()
         .chain(cw_orch::daemon::networks::OSMO_5)
-        .handle(rt.handle())
         .build()
         .unwrap();
 
@@ -239,7 +237,7 @@ use cw_orch::tokio;
 let rt = tokio::runtime::Runtime::new().unwrap();
 
 // This is the starship adapter
-let starship = Starship::new(rt.handle().to_owned(), None).unwrap();
+let starship = Starship::new(None).unwrap();
 
 // You have now an interchain environment that you can use in your application
 let interchain = starship.interchain_env();

--- a/packages/cw-orch-mock/tests/conditional.rs
+++ b/packages/cw-orch-mock/tests/conditional.rs
@@ -77,14 +77,11 @@ mod tests {
     // fn wrong_min_fee() {
     //     use cw_orch::prelude::networks;
 
-    //     let runtime = tokio::runtime::Runtime::new().unwrap();
-
     //     let mut chain = networks::UNI_6;
     //     chain.gas_price = 0.00001;
 
     //     let daemon = Daemon::builder()
     //         .chain(chain)
-    //         .handle(runtime.handle())
     //         .mnemonic("tide genuine angle mass fall promote blind skull swim army maximum add peasant fringe uncle october female crisp voyage blind extend jeans give wrap")
     //         .build()
     //         .unwrap();


### PR DESCRIPTION
This PR aims at using an existing runtime by default when no runtime is specified in the DaemonBuilder.
This allows removing runtime creation for users. 
Removed custom handles in the whole library

Chat-GPT says : 

<details>
Using lazy_static with Tokio runtimes can be a convenient approach in certain scenarios, but it's important to understand the implications and potential drawbacks.

lazy_static is a Rust crate that allows you to create lazy-initialized static variables. This means that the variable is initialized the first time it's accessed and then reused for subsequent accesses. This can be useful for initializing expensive resources once and sharing them across multiple parts of your codebase.

However, when it comes to Tokio runtimes, there are a few considerations:

    Thread Safety: Tokio runtimes are not thread-safe by default. They are designed to be used within a single-threaded context or within the context of a Tokio executor. If you use lazy_static to create a global Tokio runtime, you need to ensure that it's accessed in a thread-safe manner, especially if your application is multi-threaded.

    Resource Management: Tokio runtimes manage resources such as threads and event loops. Creating a global Tokio runtime with lazy_static means that these resources will be initialized and held for the lifetime of your application, which may not be ideal for all use cases. It could lead to resource wastage if the runtime is initialized but not actively used.

    Flexibility: Using lazy_static to create a global Tokio runtime might limit the flexibility of your codebase. It can make it harder to reason about where and how the runtime is being used, and it may not accommodate scenarios where you need multiple Tokio runtimes with different configurations.

    Testing: Global state can make unit testing more challenging. If your code relies on a global Tokio runtime created with lazy_static, it may be difficult to mock or substitute the runtime for testing purposes.

Given these considerations, it's generally recommended to carefully evaluate whether using lazy_static for Tokio runtimes aligns with the requirements and design of your application. In many cases, it might be preferable to explicitly manage the creation and lifecycle of Tokio runtimes within the scope of your application or library, rather than relying on global state.

If you do decide to use lazy_static with Tokio runtimes, make sure to thoroughly test your code and consider the potential trade-offs in terms of thread safety, resource management, and code maintainability. Additionally, document the usage and constraints of the global Tokio runtime to make it clear for other developers working on the codebase.
</details>