### PR TITLE
Update osmosis grpc port

### DIFF
--- a/packages/cw-orch-networks/src/networks/osmosis.rs
+++ b/packages/cw-orch-networks/src/networks/osmosis.rs
@@ -12,7 +12,7 @@ pub const OSMOSIS_1: ChainInfo = ChainInfo {
     chain_id: "osmosis-1",
     gas_denom: "uosmo",
     gas_price: 0.025,
-    grpc_urls: &["http://grpc.osmosis.zone:443"],
+    grpc_urls: &["https://grpc.osmosis.zone:443"],
     network_info: OSMO_NETWORK,
     lcd_url: None,
     fcd_url: None,

--- a/packages/cw-orch-networks/src/networks/osmosis.rs
+++ b/packages/cw-orch-networks/src/networks/osmosis.rs
@@ -12,7 +12,7 @@ pub const OSMOSIS_1: ChainInfo = ChainInfo {
     chain_id: "osmosis-1",
     gas_denom: "uosmo",
     gas_price: 0.025,
-    grpc_urls: &["http://grpc.osmosis.zone:9090"],
+    grpc_urls: &["http://grpc.osmosis.zone:443"],
     network_info: OSMO_NETWORK,
     lcd_url: None,
     fcd_url: None,


### PR DESCRIPTION
Seems like they silently changed grpc port (at least I haven't found any announcements) 

https://docs.osmosis.zone/overview/integrate/grpc#query-for-historical-state-using-grpcurl

> Note: This endpoint might change to grpc.osmosis.zone:443 in the near future. 