### PR TITLE
Logs custom CosmTxResponse instead of raw TxResponse

### DIFF
--- a/cw-orch-daemon/src/queriers/node.rs
+++ b/cw-orch-daemon/src/queriers/node.rs
@@ -240,9 +240,9 @@ impl Node {
         for _ in 0..retries {
             match client.get_tx(request.clone()).await {
                 Ok(tx) => {
-                    let resp = tx.into_inner().tx_response.unwrap();
+                    let resp = tx.into_inner().tx_response.unwrap().into();
                     log::debug!(target: &query_target(), "TX found: {:?}", resp);
-                    return Ok(resp.into());
+                    return Ok(resp);
                 }
                 Err(err) => {
                     // increase wait time


### PR DESCRIPTION
This PR aims at avoiding to log un-necessary information when debug-logging. 
It just logs the parsed CosmTxResponse instead of the raw TxResponse