### PR TITLE
Daemon state lock

### DIFF
--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -67,6 +67,7 @@ async-recursion = "1.0.5"
 # Gzip
 flate2 = { version = "1.0.26" }
 lazy_static = "1.4.0"
+fs4 = "0.8.2"
 
 [dev-dependencies]
 cw-orch-daemon = { path = "." }

--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -68,6 +68,7 @@ async-recursion = "1.0.5"
 flate2 = { version = "1.0.26" }
 lazy_static = "1.4.0"
 fs4 = "0.8.2"
+file-lock = "2.1.11"
 
 [dev-dependencies]
 cw-orch-daemon = { path = "." }

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -174,13 +174,13 @@ impl DaemonState {
         }
         let mut filelock = get_write_lock(&self.json_file_path);
 
-        let mut json = read_file(&filelock)?;
+        let mut json = read_file(&filelock.file)?;
 
         json[&self.chain_data.chain_name][&self.chain_data.chain_id.to_string()][key]
             [contract_id] = json!(value);
 
-        write_to_file(&mut filelock, json);
-        filelock.unlock().unwrap();
+        write_to_file(&mut filelock.file, json);
+        filelock.file.unlock().unwrap();
 
         Ok(())
     }

--- a/cw-orch-daemon/tests/simultaneous.rs
+++ b/cw-orch-daemon/tests/simultaneous.rs
@@ -1,0 +1,63 @@
+use cw_orch_core::env::STATE_FILE_ENV_NAME;
+use cw_orch_daemon::{ChainRegistryData, DaemonState};
+use cw_orch_networks::networks::JUNO_1;
+use tokio::runtime::Runtime;
+
+#[test]
+fn simultaneous_read() {
+    let runtime = Runtime::new().unwrap();
+    let _ = env_logger::try_init();
+
+    let chain_data: ChainRegistryData = JUNO_1.into();
+    std::env::set_var(STATE_FILE_ENV_NAME, "./tests/test.json");
+
+    let daemon_state = runtime
+        .block_on(DaemonState::new(chain_data, "test".to_owned(), false))
+        .unwrap();
+    daemon_state.set("test", "test", "test").unwrap();
+
+    let mut handles = vec![];
+    for _ in 0..25 {
+        let daemon_state = daemon_state.clone();
+        let handle = std::thread::spawn(move || daemon_state.get("test").unwrap());
+        handles.push(handle);
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn simultaneous_write() {
+    let runtime = Runtime::new().unwrap();
+
+    let chain_data: ChainRegistryData = JUNO_1.into();
+    std::env::set_var(STATE_FILE_ENV_NAME, "./tests/test.json");
+    let _ = env_logger::try_init();
+
+    let daemon_state = runtime
+        .block_on(DaemonState::new(chain_data, "test".to_owned(), false))
+        .unwrap();
+
+    let mut handles = vec![];
+    for i in 0..25 {
+        let daemon_state = daemon_state.clone();
+        let handle = std::thread::spawn(move || {
+            daemon_state
+                .set("test", &format!("test{i}"), format!("test-{i}"))
+                .unwrap();
+        });
+        handles.push(handle);
+    }
+
+    let mut maybe_err = Ok(());
+    // Finish all handles
+    for handle in handles {
+        let result = handle.join();
+        if result.is_err() {
+            maybe_err = result;
+        }
+    }
+    // Error if at least one failed
+    maybe_err.unwrap()
+}


### PR DESCRIPTION
This PR aims at avoiding simultaneous write/read conflicts between instances of cw-orch.
It uses:
- `file-lock` crate to avoid inter-processes conflicts
- `fs4` crate to avoid intra-processes conflicts



`fs4` needs a manual unlock
`file-lock` is automatically unlocked when `FileLock` variable gets out of scope