### PR TITLE
Added backwards compatibility-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added a test to make sure the derive macros stay compatible with new cw-orch versions
+
+## 0.22
+
 - Updated osmosis test tube to 24.0.1 ,that avoids re-compiling osmosis test tube
 - Added `balance` query at the root of QueryHandler
 - Added DaemonBuilder configuration for grpc url and fee overwriting

--- a/contracts/compatibility-test/Cargo.toml
+++ b/contracts/compatibility-test/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "cw-orch-compatibility-test"
+version = "0.1.0"
+description = "Mock constract for cw-orch macro testing"
+keywords = ["cosmwasm", "blockchain"]
+edition = { workspace = true }
+
+exclude = [".env"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["export"]
+export = []
+interface = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+serde = { workspace = true }
+schemars = "0.8.10"
+serde_json = "1.0.79"
+thiserror = { version = "1.0.21" }
+cosmwasm-schema = "1.2"
+# This version should not be a path dependency and be kept to the last cw-orch version (beyond v0.23)
+# Keeping a different package until v0.23 to avoid package conflicts
+cw-orch = { package = "aaa-test-cw-orch", version = "0.22" }
+# Keep the old-cw-orch version to 0.22 for backwards compatibility
+old-cw-orch = { package = "cw-orch", version = "0.22" }

--- a/contracts/compatibility-test/README.md
+++ b/contracts/compatibility-test/README.md
@@ -1,0 +1,2 @@
+This folder is used for testing backwards compatibility of cw-orch macros with the older macro versions.
+The cw-orch version needs to stay at 0.22 for this test because it's the first stable version of cw-orch-core.

--- a/contracts/compatibility-test/src/lib.rs
+++ b/contracts/compatibility-test/src/lib.rs
@@ -51,7 +51,7 @@ pub fn instantiate(
 pub fn execute(
     _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     msg: ExecuteMsg,
 ) -> StdResult<Response> {
     match msg {

--- a/contracts/compatibility-test/src/lib.rs
+++ b/contracts/compatibility-test/src/lib.rs
@@ -1,0 +1,139 @@
+mod msg_tests;
+
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+
+#[cw_serde]
+pub struct InstantiateMsg {}
+
+#[cw_serde]
+#[derive(old_cw_orch::ExecuteFns)]
+pub enum ExecuteMsg {
+    FirstMessage {},
+    #[payable]
+    SecondMessage {
+        /// test doc-comment
+        t: String,
+    },
+}
+
+#[cw_serde]
+#[derive(old_cw_orch::QueryFns, QueryResponses)]
+pub enum QueryMsg {
+    #[returns(String)]
+    /// test-doc-comment
+    FirstQuery {},
+    #[returns(u64)]
+    SecondQuery {
+        /// test doc-comment
+        t: String,
+    },
+}
+
+#[cw_serde]
+pub struct MigrateMsg {
+    pub t: String,
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn instantiate(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> StdResult<Response> {
+    Ok(Response::new().add_attribute("action", "instantiate"))
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn execute(
+    _deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::FirstMessage {} => {
+            Ok(Response::new().add_attribute("action", "first message passed"))
+        }
+        ExecuteMsg::SecondMessage { t: _ } => {
+            Ok(Response::new().add_attribute("action", "first message passed"))
+        }
+    }
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::FirstQuery {} => to_json_binary("first query passed"),
+        QueryMsg::SecondQuery { .. } => to_json_binary(&89u64),
+    }
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
+    if msg.t.eq("success") {
+        Ok(Response::new())
+    } else {
+        Err(StdError::generic_err(
+            "migrate endpoint reached but no test implementation",
+        ))
+    }
+}
+
+#[cw_orch::interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
+pub struct MockContract;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod interface {
+    use old_cw_orch::environment::ChainInfoOwned;
+
+    use crate::{execute, instantiate, migrate, query, MockContract};
+
+    impl<Chain> old_cw_orch::prelude::Uploadable for MockContract<Chain> {
+        fn wrapper(
+        ) -> Box<dyn old_cw_orch::prelude::MockContract<cosmwasm_std::Empty, cosmwasm_std::Empty>>
+        {
+            Box::new(
+                old_cw_orch::prelude::ContractWrapper::new(execute, instantiate, query)
+                    .with_migrate(migrate),
+            )
+        }
+
+        fn wasm(_chain: &ChainInfoOwned) -> old_cw_orch::prelude::WasmPath {
+            use old_cw_orch::prelude::*;
+            artifacts_dir_from_workspace!()
+                .find_wasm_path("mock_contract")
+                .unwrap()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::MockContract as LocalMockContract;
+    use super::*;
+    use cosmwasm_std::coins;
+    use cw_orch::prelude::*;
+
+    #[test]
+    fn compiles() -> Result<(), CwOrchError> {
+        // We need to check we can still call the execute msgs conveniently
+        let sender = Addr::unchecked("sender");
+        let mock = Mock::new(&sender);
+        mock.set_balance(&sender, coins(156 * 2, "ujuno"))?;
+        let contract = LocalMockContract::new("mock-contract", mock.clone());
+
+        contract.upload()?;
+        contract.instantiate(&InstantiateMsg {}, None, None)?;
+        contract.first_message()?;
+        contract.second_message("s".to_string(), &coins(156, "ujuno"))?;
+
+        contract.first_query()?;
+        contract.second_query("arg".to_string())?;
+
+        Ok(())
+    }
+}

--- a/contracts/compatibility-test/src/msg_tests.rs
+++ b/contracts/compatibility-test/src/msg_tests.rs
@@ -1,0 +1,103 @@
+// Here we implement some tests for the interface macros to make sure everything works and keeps working
+// This is a contract not exposed, only used for compilation test (necessary)
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult};
+
+// ANCHOR: unordered_msg_def
+#[cw_serde]
+#[derive(cw_orch::ExecuteFns)]
+#[disable_fields_sorting]
+pub enum ExecuteMsg {
+    Test { b: u64, a: String },
+}
+// ANCHOR_END: unordered_msg_def
+
+// ANCHOR: ordered_msg_def
+#[cw_serde]
+#[derive(cw_orch::ExecuteFns)]
+pub enum ExecuteMsgOrdered {
+    Test { b: u64, a: String },
+}
+// ANCHOR_END: ordered_msg_def
+
+#[cw_orch::interface(Empty, ExecuteMsg, Empty, Empty)]
+pub struct TestContract;
+
+#[cw_orch::interface(Empty, ExecuteMsgOrdered, Empty, Empty)]
+pub struct OrderedTestContract;
+
+pub fn instantiate(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: Empty,
+) -> StdResult<Response> {
+    Ok(Response::new())
+}
+
+pub fn execute(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: ExecuteMsg,
+) -> StdResult<Response> {
+    Ok(Response::new())
+}
+
+pub fn execute_ordered(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: ExecuteMsgOrdered,
+) -> StdResult<Response> {
+    Ok(Response::new())
+}
+
+pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+    Ok(vec![].into())
+}
+#[cfg(not(target_arch = "wasm32"))]
+mod interface {
+    use super::*;
+    use cw_orch::prelude::*;
+
+    impl<Chain> Uploadable for TestContract<Chain> {
+        fn wrapper() -> <Mock as TxHandler>::ContractSource {
+            Box::new(ContractWrapper::new_with_empty(execute, instantiate, query))
+        }
+    }
+
+    impl<Chain> Uploadable for OrderedTestContract<Chain> {
+        fn wrapper() -> <Mock as TxHandler>::ContractSource {
+            Box::new(ContractWrapper::new_with_empty(
+                execute_ordered,
+                instantiate,
+                query,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cw_orch::prelude::*;
+    #[test]
+    pub fn test() -> Result<(), CwOrchError> {
+        let chain = Mock::new("sender");
+
+        let contract = TestContract::new("test", chain.clone());
+        let contract_ordered = OrderedTestContract::new("test-ordered", chain.clone());
+
+        contract.upload()?;
+        contract_ordered.upload()?;
+        contract.instantiate(&Empty {}, None, None)?;
+        contract_ordered.instantiate(&Empty {}, None, None)?;
+
+        contract.test(5, "test".to_string())?;
+        contract_ordered.test("test".to_string(), 5)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR aims at adding a contract to test cw-orch backwards compatibility on the provided macros.
This is very useful to make sure that the cw-orch-core stabilitization was useful.