### PR TITLE
Use only cw-orch-core inside derive macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Changed the derive macros import from cw_orch to cw_orch_core. This allows changing the cw-orch API without breaking the derive macros.
+
+## 0.22.0
+
 - Updated osmosis test tube to 24.0.1 ,that avoids re-compiling osmosis test tube
 - Added `balance` query at the root of QueryHandler
 - Added DaemonBuilder configuration for grpc url and fee overwriting

--- a/cw-orch/src/lib.rs
+++ b/cw-orch/src/lib.rs
@@ -32,6 +32,7 @@ pub mod wasm_protected {
     /// Re-export anyhow for use in the macros
     pub extern crate anyhow;
 
+    // This re-export should not be touched or the derive macros WILL break
     pub use cw_orch_core as core;
     pub use cw_orch_core::{build, contract};
 

--- a/cw-orch/src/lib.rs
+++ b/cw-orch/src/lib.rs
@@ -32,6 +32,7 @@ pub mod wasm_protected {
     /// Re-export anyhow for use in the macros
     pub extern crate anyhow;
 
+    pub use cw_orch_core as core;
     pub use cw_orch_core::{build, contract};
 
     /// Related to execution environments

--- a/packages/cw-orch-contract-derive/src/lib.rs
+++ b/packages/cw-orch-contract-derive/src/lib.rs
@@ -95,22 +95,22 @@ This generated the following code:
 ```ignore
 
 // This struct represents the interface to the contract.
-pub struct Cw20<Chain>(::cw_orch::prelude::Contract<Chain>);
+pub struct Cw20<Chain>(::cw_orch::core::contract::Contract<Chain>);
 
 impl <Chain> Cw20<Chain> {
     /// Constructor for the contract interface
      pub fn new(contract_id: impl ToString, chain: Chain) -> Self {
         Self(
-            ::cw_orch::contract::Contract::new(contract_id, chain)
+            ::cw_orch::core::contract::Contract::new(contract_id, chain)
         )
     }
 }
 
 // Traits for signaling cw-orchestrator with what messages to call the contract's entry points.
-impl <Chain> ::cw_orch::prelude::InstantiableContract for Cw20<Chain> {
+impl <Chain> ::cw_orch::core::contract::interface_traits::InstantiableContract for Cw20<Chain> {
     type InstantiateMsg = InstantiateMsg;
 }
-impl <Chain> ::cw_orch::prelude::ExecutableContract for Cw20<Chain> {
+impl <Chain> ::cw_orch::core::contract::interface_traits::ExecutableContract for Cw20<Chain> {
     type ExecuteMsg = ExecuteMsg;
 }
 // ... other entry point & upload traits
@@ -207,7 +207,7 @@ pub fn interface(attrs: TokenStream, input: TokenStream) -> TokenStream {
             impl <Chain, #all_generics> #name<Chain, #all_generics> {
                 pub fn new(chain: Chain) -> Self {
                     Self(
-                        ::cw_orch::contract::Contract::new(#id_expr, chain)
+                        ::cw_orch::core::contract::Contract::new(#id_expr, chain)
                     , #(#all_phantom_marker_values,)*)
                 }
             }
@@ -217,7 +217,7 @@ pub fn interface(attrs: TokenStream, input: TokenStream) -> TokenStream {
             impl <Chain, #all_generics> #name<Chain, #all_generics> {
                 pub fn new(contract_id: impl ToString, chain: Chain) -> Self {
                     Self(
-                        ::cw_orch::contract::Contract::new(contract_id, chain)
+                        ::cw_orch::core::contract::Contract::new(contract_id, chain)
                     , #(#all_phantom_marker_values,)*)
                 }
             }
@@ -228,7 +228,7 @@ pub fn interface(attrs: TokenStream, input: TokenStream) -> TokenStream {
         #[derive(
             ::std::clone::Clone,
         )]
-        pub struct #name<Chain, #all_generics>(::cw_orch::contract::Contract<Chain>, #(#all_phantom_markers,)*);
+        pub struct #name<Chain, #all_generics>(::cw_orch::core::contract::Contract<Chain>, #(#all_phantom_markers,)*);
 
         #[cfg(target_arch = "wasm32")]
         #[derive(
@@ -240,32 +240,32 @@ pub fn interface(attrs: TokenStream, input: TokenStream) -> TokenStream {
         #default_num
 
         #[cfg(not(target_arch = "wasm32"))]
-        impl<Chain: ::cw_orch::environment::ChainState, #all_generics> ::cw_orch::prelude::ContractInstance<Chain> for #name<Chain, #all_generics> {
-            fn as_instance(&self) -> &::cw_orch::contract::Contract<Chain> {
+        impl<Chain: ::cw_orch::core::environment::ChainState, #all_generics> ::cw_orch::core::contract::interface_traits::ContractInstance<Chain> for #name<Chain, #all_generics> {
+            fn as_instance(&self) -> &::cw_orch::core::contract::Contract<Chain> {
                 &self.0
             }
-            fn as_instance_mut(&mut self) -> &mut ::cw_orch::contract::Contract<Chain> {
+            fn as_instance_mut(&mut self) -> &mut ::cw_orch::core::contract::Contract<Chain> {
                 &mut self.0
             }
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        impl<Chain, #all_generics> ::cw_orch::prelude::InstantiableContract for #name<Chain, #all_generics> #all_debug_serialize {
+        impl<Chain, #all_generics> ::cw_orch::core::contract::interface_traits::InstantiableContract for #name<Chain, #all_generics> #all_debug_serialize {
             type InstantiateMsg = #init;
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        impl<Chain, #all_generics> ::cw_orch::prelude::ExecutableContract for #name<Chain, #all_generics> #all_debug_serialize {
+        impl<Chain, #all_generics> ::cw_orch::core::contract::interface_traits::ExecutableContract for #name<Chain, #all_generics> #all_debug_serialize {
             type ExecuteMsg = #exec;
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        impl<Chain, #all_generics> ::cw_orch::prelude::QueryableContract for #name<Chain, #all_generics> #all_debug_serialize {
+        impl<Chain, #all_generics> ::cw_orch::core::contract::interface_traits::QueryableContract for #name<Chain, #all_generics> #all_debug_serialize {
             type QueryMsg = #query;
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        impl<Chain, #all_generics> ::cw_orch::prelude::MigratableContract for #name<Chain, #all_generics> #all_debug_serialize {
+        impl<Chain, #all_generics> ::cw_orch::core::contract::interface_traits::MigratableContract for #name<Chain, #all_generics> #all_debug_serialize {
             type MigrateMsg = #migrate;
         }
     );

--- a/packages/cw-orch-fns-derive/src/execute_fns.rs
+++ b/packages/cw-orch-fns-derive/src/execute_fns.rs
@@ -78,11 +78,11 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
                 quote!(
                     #variant_doc
                     #[allow(clippy::too_many_arguments)]
-                    fn #variant_func_name(&self, #(#variant_attr,)* #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
+                    fn #variant_func_name(&self, #(#variant_attr,)* #maybe_coins_attr) -> Result<::cw_orch::core::environment::TxResponse<Chain>, ::cw_orch::core::CwEnvError> {
                         let msg = #name::#variant_name (
                             #(#variant_ident_content_names,)*
                         );
-                        <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
+                        <Self as ::cw_orch::core::contract::interface_traits::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
                     }
                 )
             },
@@ -90,9 +90,9 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
 
                 quote!(
                     #variant_doc
-                    fn #variant_func_name(&self, #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
+                    fn #variant_func_name(&self, #maybe_coins_attr) -> Result<::cw_orch::core::environment::TxResponse<Chain>, ::cw_orch::core::CwEnvError> {
                         let msg = #name::#variant_name;
-                        <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
+                        <Self as ::cw_orch::core::contract::interface_traits::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
                     }
                 )
             }
@@ -114,11 +114,11 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
                 quote!(
                     #variant_doc
                     #[allow(clippy::too_many_arguments)]
-                    fn #variant_func_name(&self, #(#variant_attr,)* #maybe_coins_attr) -> Result<::cw_orch::prelude::TxResponse<Chain>, ::cw_orch::prelude::CwOrchError> {
+                    fn #variant_func_name(&self, #(#variant_attr,)* #maybe_coins_attr) -> Result<::cw_orch::core::environment::TxResponse<Chain>, ::cw_orch::core::CwEnvError> {
                         let msg = #name::#variant_name {
                             #(#variant_ident_content_names,)*
                         };
-                        <Self as ::cw_orch::prelude::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
+                        <Self as ::cw_orch::core::contract::interface_traits::CwOrchExecute<Chain>>::execute(self, &msg #maybe_into,#passed_coins)
                     }
                 )
             }
@@ -128,7 +128,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
     let derived_trait = quote!(
         #[cfg(not(target_arch = "wasm32"))]
         /// Automatically derived trait that allows you to call the variants of the message directly without the need to construct the struct yourself.
-        pub trait #bname<Chain: ::cw_orch::prelude::TxHandler, #type_generics>: ::cw_orch::prelude::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics> #where_clause {
+        pub trait #bname<Chain: ::cw_orch::core::environment::TxHandler, #type_generics>: ::cw_orch::core::contract::interface_traits::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics> #where_clause {
             #(#variant_fns)*
         }
 
@@ -141,7 +141,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
 
     // We need to merge the where clauses (rust doesn't support 2 wheres)
     // If there is no where clause, we simply add the necessary where
-    let necessary_where = quote!(SupportedContract: ::cw_orch::prelude::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics >);
+    let necessary_where = quote!(SupportedContract: ::cw_orch::core::contract::interface_traits::CwOrchExecute<Chain, ExecuteMsg = #entrypoint_msg_type #ty_generics >);
     let combined_where_clause = where_clause
         .map(|w| {
             quote!(
@@ -155,7 +155,7 @@ pub fn execute_fns_derive(input: DeriveInput) -> TokenStream {
 
     let derived_trait_impl = quote!(
         #[automatically_derived]
-        impl<SupportedContract, Chain: ::cw_orch::prelude::TxHandler, #type_generics> #bname<Chain, #type_generics> for SupportedContract
+        impl<SupportedContract, Chain: ::cw_orch::core::environment::TxHandler, #type_generics> #bname<Chain, #type_generics> for SupportedContract
         #combined_where_clause {}
     );
 

--- a/packages/cw-orch-fns-derive/src/query_fns.rs
+++ b/packages/cw-orch-fns-derive/src/query_fns.rs
@@ -73,18 +73,18 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                 quote!(
                     #variant_doc
                     #[allow(clippy::too_many_arguments)]
-                    fn #variant_func_name(&self, #(#variant_attr,)*) -> ::core::result::Result<#response, ::cw_orch::prelude::CwOrchError> {
+                    fn #variant_func_name(&self, #(#variant_attr,)*) -> ::core::result::Result<#response, ::cw_orch::core::CwEnvError> {
                         let msg = #name::#variant_name (#(#variant_ident_content_names,)*);
-                        <Self as ::cw_orch::prelude::CwOrchQuery<Chain>>::query(self,&msg #maybe_into)
+                        <Self as ::cw_orch::core::contract::interface_traits::CwOrchQuery<Chain>>::query(self,&msg #maybe_into)
                     }
                 )
             }
             Fields::Unit => {
                 quote!(
                     #variant_doc
-                    fn #variant_func_name(&self) -> ::core::result::Result<#response, ::cw_orch::prelude::CwOrchError> {
+                    fn #variant_func_name(&self) -> ::core::result::Result<#response, ::cw_orch::core::CwEnvError> {
                         let msg = #name::#variant_name;
-                        <Self as ::cw_orch::prelude::CwOrchQuery<Chain>>::query(self, &msg #maybe_into)
+                        <Self as ::cw_orch::core::contract::interface_traits::CwOrchQuery<Chain>>::query(self, &msg #maybe_into)
                     }
                 )
             },
@@ -105,11 +105,11 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                 quote!(
                     #variant_doc
                     #[allow(clippy::too_many_arguments)]
-                    fn #variant_func_name(&self, #(#variant_attr,)*) -> ::core::result::Result<#response, ::cw_orch::prelude::CwOrchError> {
+                    fn #variant_func_name(&self, #(#variant_attr,)*) -> ::core::result::Result<#response, ::cw_orch::core::CwEnvError> {
                         let msg = #name::#variant_name {
                             #(#variant_idents,)*
                         };
-                        <Self as ::cw_orch::prelude::CwOrchQuery<Chain>>::query(self, &msg #maybe_into)
+                        <Self as ::cw_orch::core::contract::interface_traits::CwOrchQuery<Chain>>::query(self, &msg #maybe_into)
                     }
                 )
             }
@@ -119,7 +119,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
     let derived_trait = quote!(
         #[cfg(not(target_arch = "wasm32"))]
         /// Automatically derived trait that allows you to call the variants of the message directly without the need to construct the struct yourself.
-        pub trait #bname<Chain: ::cw_orch::prelude::QueryHandler + ::cw_orch::environment::ChainState, #type_generics>: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics > #where_clause {
+        pub trait #bname<Chain: ::cw_orch::core::environment::QueryHandler + ::cw_orch::core::environment::ChainState, #type_generics>: ::cw_orch::core::contract::interface_traits::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics > #where_clause {
             #(#variant_fns)*
         }
 
@@ -132,7 +132,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
 
     // We need to merge the where clauses (rust doesn't support 2 wheres)
     // If there is no where clause, we simply add the necessary where
-    let necessary_where = quote!(SupportedContract: ::cw_orch::prelude::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics >);
+    let necessary_where = quote!(SupportedContract: ::cw_orch::core::contract::interface_traits::CwOrchQuery<Chain, QueryMsg = #entrypoint_msg_type #ty_generics >);
     let combined_where_clause = where_clause
         .map(|w| {
             quote!(
@@ -146,7 +146,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
 
     let derived_trait_impl = quote!(
         #[automatically_derived]
-        impl<SupportedContract, Chain: ::cw_orch::prelude::QueryHandler + ::cw_orch::environment::ChainState, #type_generics> #bname<Chain, #type_generics> for SupportedContract
+        impl<SupportedContract, Chain: ::cw_orch::core::environment::QueryHandler + ::cw_orch::core::environment::ChainState, #type_generics> #bname<Chain, #type_generics> for SupportedContract
         #combined_where_clause {}
     );
 


### PR DESCRIPTION
This PR aims at removing the dependency on cw-orch structure for the derives macros.
They now only depend on cw_orch::core. This re-export of cw-orch-core should NEVER be touched