### PR TITLE
Helpers to querying raw state outside contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a test to make sure the derive macros stay compatible with new cw-orch versions
 - Changed the derive macros import from cw_orch to cw_orch_core. This allows changing the cw-orch API without breaking the derive macros.
 - Cw-orch mock env info doesn't error when using chain ids that don't match the `osmosis-1` pattern
+- Added an item query method to be able to query storage structure outside of contracts
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Changed the derive macros import from cw_orch to cw_orch_core. This allows changing the cw-orch API without breaking the derive macros.
 - Cw-orch mock env info doesn't error when using chain ids that don't match the `osmosis-1` pattern
 - Remove `impl_into`, the old `impl_into` behavior is now the default behavior
-- Added an item and a map query method to be able to query cw-storage-plus structure outside of contracts easily
+- EXCITING FEATURE : Added an item and a map query method to be able to query cw-storage-plus structure outside of contracts easily
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added a test to make sure the derive macros stay compatible with new cw-orch versions
 - Changed the derive macros import from cw_orch to cw_orch_core. This allows changing the cw-orch API without breaking the derive macros.
 - Cw-orch mock env info doesn't error when using chain ids that don't match the `osmosis-1` pattern
-- Added an item query method to be able to query storage structure outside of contracts
+- Added an item and a map query method to be able to query cw-storage-plus structure outside of contracts easily
 
 ### Breaking
 

--- a/contracts/mock_contract/Cargo.toml
+++ b/contracts/mock_contract/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = "1.0.79"
 thiserror = { version = "1.0.21" }
 cosmwasm-schema = "1.2"
 cw-orch = { path = "../../cw-orch" }
+cw-storage-plus = { version = "1.2.0" }

--- a/packages/cw-orch-core/Cargo.toml
+++ b/packages/cw-orch-core/Cargo.toml
@@ -42,6 +42,7 @@ cw-utils.workspace = true
 cosmos-sdk-proto = { version = "0.21.1", default-features = false, features = [
   "cosmwasm",
 ] }
+cw-storage-plus = "1.2.0"
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/packages/cw-orch-core/src/contract/interface_traits.rs
+++ b/packages/cw-orch-core/src/contract/interface_traits.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use cosmwasm_std::{Addr, Binary, Coin, Empty};
 use cw_multi_test::Contract as MockContract;
+use cw_storage_plus::{Item, Map, PrimaryKey};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
@@ -151,6 +152,27 @@ pub trait CwOrchQuery<Chain: QueryHandler + ChainState>:
         query_msg: &Self::QueryMsg,
     ) -> Result<G, CwEnvError> {
         self.as_instance().query(query_msg)
+    }
+
+    /// Query the contract raw state from an item
+    fn item_query<T: Serialize + DeserializeOwned>(
+        &self,
+        query_item: Item<T>,
+    ) -> Result<T, CwEnvError> {
+        self.get_chain()
+            .wasm_querier()
+            .item_query(self.address()?, query_item)
+    }
+
+    /// Query the contract raw state from an item
+    fn map_query<'a, T: Serialize + DeserializeOwned, K: PrimaryKey<'a>>(
+        &self,
+        query_map: Map<'a, K, T>,
+        key: K,
+    ) -> Result<T, CwEnvError> {
+        self.get_chain()
+            .wasm_querier()
+            .map_query(self.address()?, query_map, key)
     }
 }
 

--- a/packages/cw-orch-core/src/contract/interface_traits.rs
+++ b/packages/cw-orch-core/src/contract/interface_traits.rs
@@ -154,7 +154,15 @@ pub trait CwOrchQuery<Chain: QueryHandler + ChainState>:
         self.as_instance().query(query_msg)
     }
 
-    /// Query the contract raw state from an item
+    /// Query the contract raw state from an raw binary key
+    fn raw_query(&self, query_keys: Vec<u8>) -> Result<Vec<u8>, CwEnvError> {
+        self.get_chain()
+            .wasm_querier()
+            .raw_query(self.address()?, query_keys)
+            .map_err(Into::into)
+    }
+
+    /// Query the contract raw state from an cw-storage-plus::Item
     fn item_query<T: Serialize + DeserializeOwned>(
         &self,
         query_item: Item<T>,
@@ -164,7 +172,7 @@ pub trait CwOrchQuery<Chain: QueryHandler + ChainState>:
             .item_query(self.address()?, query_item)
     }
 
-    /// Query the contract raw state from an item
+    /// Query the contract raw state from a cw-storage-plus::Map
     fn map_query<'a, T: Serialize + DeserializeOwned, K: PrimaryKey<'a>>(
         &self,
         query_map: Map<'a, K, T>,

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{from_json, CodeInfoResponse, ContractInfoResponse, HexBinary};
-use cw_storage_plus::Item;
+use cw_storage_plus::{Item, Map, PrimaryKey};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -36,6 +36,18 @@ pub trait WasmQuerier: Querier {
         let current_manager_version = self
             .raw_query(address, item.as_slice().to_vec())
             .map_err(Into::into)?;
+
+        from_json(current_manager_version).map_err(Into::into)
+    }
+
+    fn map_query<'a, T: Serialize + DeserializeOwned, K: PrimaryKey<'a>>(
+        &self,
+        address: impl Into<String>,
+        map: Map<'a, K, T>,
+        key: K,
+    ) -> Result<T, CwEnvError> {
+        let total_key = map.key(key).to_vec();
+        let current_manager_version = self.raw_query(address, total_key).map_err(Into::into)?;
 
         from_json(current_manager_version).map_err(Into::into)
     }

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -1,4 +1,5 @@
-use cosmwasm_std::{CodeInfoResponse, ContractInfoResponse, HexBinary};
+use cosmwasm_std::{from_json, CodeInfoResponse, ContractInfoResponse, HexBinary};
+use cw_storage_plus::Item;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -26,6 +27,18 @@ pub trait WasmQuerier: Querier {
         address: impl Into<String>,
         query_keys: Vec<u8>,
     ) -> Result<Vec<u8>, Self::Error>;
+
+    fn item_query<T: Serialize + DeserializeOwned>(
+        &self,
+        address: impl Into<String>,
+        item: Item<T>,
+    ) -> Result<T, CwEnvError> {
+        let current_manager_version = self
+            .raw_query(address, item.as_slice().to_vec())
+            .map_err(Into::into)?;
+
+        from_json(current_manager_version).map_err(Into::into)
+    }
 
     fn smart_query<Q: Serialize, T: DeserializeOwned>(
         &self,

--- a/packages/cw-orch-core/src/environment/queriers/wasm.rs
+++ b/packages/cw-orch-core/src/environment/queriers/wasm.rs
@@ -33,11 +33,11 @@ pub trait WasmQuerier: Querier {
         address: impl Into<String>,
         item: Item<T>,
     ) -> Result<T, CwEnvError> {
-        let current_manager_version = self
+        let raw_value = self
             .raw_query(address, item.as_slice().to_vec())
             .map_err(Into::into)?;
 
-        from_json(current_manager_version).map_err(Into::into)
+        from_json(raw_value).map_err(Into::into)
     }
 
     fn map_query<'a, T: Serialize + DeserializeOwned, K: PrimaryKey<'a>>(


### PR DESCRIPTION
This PR aims at adding a simple helper to query raw state from outside contracts.
Types are derived automatically.

You can use the following syntax : 
```rust
const TEST_ITEM: Item<TestItem> = Item::new("test-item");
const TEST_MAP: Map<String, TestItem> = Map::new("test-map");

let contract = Contract::new(chain);
contract.item_query(TEST_ITEM);
contract.map_query(MAP_ITEM, map_key);
```

Do you think we should use this instead  : 
```rust
TEST_ITEM.cw_orch_query(&contract)?;
MAP_ITEM.cw_orch_query(&contract, map_key)?;
```
