### PR TITLE
generate new `Sender` if hd_index was provided in set_options

### DIFF
--- a/cw-orch-daemon/src/keys/private.rs
+++ b/cw-orch-daemon/src/keys/private.rs
@@ -181,6 +181,7 @@ impl PrivateKey {
         Ok(private_key)
     }
 
+    // Generate private key from private key bytes
     fn gen_private_key_raw<C: secp256k1::Signing + secp256k1::Context>(
         secp: &Secp256k1<C>,
         raw_key: &[u8],

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -158,6 +158,7 @@ fn overwrite_grpc_url(chain: &mut ChainInfoOwned, grpc_url: Option<String>) {
 
 #[cfg(test)]
 mod test {
+    use cw_orch_core::environment::TxHandler;
     use cw_orch_networks::networks::OSMOSIS_1;
 
     use crate::DaemonBuilder;
@@ -226,5 +227,24 @@ mod test {
         assert_eq!(daemon.daemon.state.chain_data.gas_denom, token.to_string());
 
         assert_eq!(daemon.daemon.state.chain_data.gas_price, fee_amount);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn hd_index_re_generates_sender() -> anyhow::Result<()> {
+        let daemon = DaemonBuilder::default()
+            .chain(OSMOSIS_1)
+            .mnemonic(DUMMY_MNEMONIC)
+            .build()
+            .unwrap();
+
+        let indexed_daemon = daemon.rebuild().hd_index(56).build().unwrap();
+
+        assert_ne!(
+            daemon.sender().to_string(),
+            indexed_daemon.sender().to_string()
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
hd_index impacts private key meaning if it's provided inside `SenderOptions` new Sender should be created from scratch
Closes ORC-127, Closes ORC-125