### PR TITLE
Added failure on no packets found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove `impl_into`, the old `impl_into` behavior is now the default behavior
 - EXCITING FEATURE : Added an item and a map query method to be able to query cw-storage-plus structure outside of contracts easily
 - Add `flush_state` method for Local Chain Daemons
+- cw-orch-interchain now errors on checking transactions for IBC packets if NO packets were found
 
 ### Breaking
 

--- a/packages/interchain/interchain-core/src/env.rs
+++ b/packages/interchain/interchain-core/src/env.rs
@@ -1,6 +1,6 @@
 //! This module contains the trait definition for an interchain analysis environment
 
-use cosmwasm_std::{Binary, IbcOrder};
+use cosmwasm_std::{ensure, Binary, IbcOrder};
 use cw_orch_core::{
     contract::interface_traits::ContractInstance,
     environment::{CwEnv, IndexResponse, TxHandler},
@@ -236,6 +236,12 @@ pub trait InterchainEnv<Chain: IbcQueryHandler> {
         tx_response: <Chain as TxHandler>::Response,
     ) -> Result<(), InterchainError> {
         let tx_result = self.wait_ibc(chain_id, tx_response).map_err(Into::into)?;
+
+        ensure!(
+            !tx_result.get_success_packets()?.is_empty(),
+            InterchainError::NoPacketsFound {}
+        );
+
         tx_result.into_result()
     }
 

--- a/packages/interchain/interchain-core/src/error.rs
+++ b/packages/interchain/interchain-core/src/error.rs
@@ -53,6 +53,9 @@ pub enum InterchainError {
     #[error("Some packets were not parsed by the given parsing functions")]
     RemainingPackets {},
 
+    #[error("No packets were found while following packets")]
+    NoPacketsFound {},
+
     #[error("Failure acknowledgment received: {0:?}")]
     FailedAckReceived(String),
 }


### PR DESCRIPTION
This PR adds errors when using `check_ibc` if no packet is present in the transaction following process

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
