### PR TITLE
Nicolas/orc 136 list of attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Two non-related Daemon's can't use same file for writing simultaneously (cloned or rebuilt are related Daemon)
 - Writing to a file happens when all Daemon's that use same file dropped instead of hot writes
 - `force_write` added to the `DaemonState` to allow force write of the state
+- Added `event_attr_values` to get all the attribute values corresponding to a key
 
 ### Breaking
 

--- a/cw-orch-daemon/src/tx_resp.rs
+++ b/cw-orch-daemon/src/tx_resp.rs
@@ -207,6 +207,21 @@ impl IndexResponse for CosmTxResponse {
             "event of type {event_type} does not have a value at key {attr_key}"
         )))
     }
+
+    fn event_attr_values(&self, event_type: &str, attr_key: &str) -> Vec<String> {
+        let mut all_results = vec![];
+
+        for event in &self.events {
+            if event.r#type == event_type {
+                for attr in &event.attributes {
+                    if attr.key == attr_key {
+                        all_results.push(parse_attribute_bytes(&attr.value));
+                    }
+                }
+            }
+        }
+        all_results
+    }
 }
 
 /// The events from a single message in a transaction.

--- a/packages/clone-testing/src/core.rs
+++ b/packages/clone-testing/src/core.rs
@@ -402,6 +402,21 @@ impl IndexResponse for AppResponse {
             event_type, attr_key
         )))
     }
+
+    fn event_attr_values(&self, event_type: &str, attr_key: &str) -> Vec<String> {
+        let mut all_results = vec![];
+
+        for event in &self.events {
+            if event.ty == event_type {
+                for attr in &event.attributes {
+                    if attr.key == attr_key {
+                        all_results.push(attr.value.clone());
+                    }
+                }
+            }
+        }
+        all_results
+    }
 }
 
 impl BankSetter for CloneTesting {

--- a/packages/cw-orch-core/src/environment/index_response.rs
+++ b/packages/cw-orch-core/src/environment/index_response.rs
@@ -23,6 +23,12 @@ pub trait IndexResponse {
     /// Search for an event with given attribute key.
     fn event_attr_value(&self, event_type: &str, attr_key: &str) -> StdResult<String>;
 
+    /// Search for all events with a given attribute key.
+    fn event_attr_values(&self, _event_type: &str, _attr_key: &str) -> Vec<String> {
+        // This is provided to avoid breaking changes to cw-orch-core
+        unimplemented!("");
+    }
+
     /// Get the data field of the response.
     fn data(&self) -> Option<Binary>;
 
@@ -91,6 +97,21 @@ impl IndexResponse for AppResponse {
             "missing combination (event: {}, attribute: {})",
             event_type, attr_key
         )))
+    }
+
+    fn event_attr_values(&self, event_type: &str, attr_key: &str) -> Vec<String> {
+        let mut all_results = vec![];
+
+        for event in &self.events {
+            if event.ty == event_type {
+                for attr in &event.attributes {
+                    if attr.key == attr_key {
+                        all_results.push(attr.value.clone());
+                    }
+                }
+            }
+        }
+        all_results
     }
 }
 


### PR DESCRIPTION
This Pr aims at adding `event_attr_values` function to `IndexResponse` to get all the attributes to a value.

The trait provides a default implementation to avoid breaking changes to cw-orch-core

### Checklist

- [x] Changelog updated.
- [x] Docs updated.
