### PR TITLE
DaemonState: `write_on_change`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - Added `event_attr_values` to get all the attribute values corresponding to a key
 - Added `remove_{address,code_id}` functions to be able to erase an entry in state. Involves core, mock, daemon, osmosis-test-tube, clone-testing
 - Added `state` to DaemonBuilder to be able to share state between daemons
-  
+- Added `write_on_change` flag for writing to a `DaemonState` file on every change
+
 ### Breaking
 
 - Daemon : Changed return types on daemon queriers to match CosmWasm std types

--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -99,7 +99,7 @@ impl DaemonAsyncBuilder {
         self
     }
 
-    /// Wether to write on every change of the state
+    /// Whether to write on every change of the state
     /// If `true` - writes to a file on every change
     /// If `false` - writes to a file when all Daemons dropped this [`DaemonState`] or [`DaemonState::force_write`] used
     /// Defaults to `true`

--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -32,6 +32,9 @@ pub struct DaemonAsyncBuilder {
     // # Optional
     pub(crate) deployment_id: Option<String>,
     pub(crate) state_path: Option<String>,
+    /// State from rebuild or existing daemon
+    pub(crate) state: Option<DaemonState>,
+    pub(crate) write_on_change: Option<bool>,
 
     /* Sender related options */
     /// Wallet sender
@@ -39,9 +42,6 @@ pub struct DaemonAsyncBuilder {
     pub(crate) sender: Option<SenderBuilder<All>>,
     /// Specify Daemon Sender Options
     pub(crate) sender_options: SenderOptions,
-
-    /* Rebuilder related options */
-    pub(crate) state: Option<DaemonState>,
 }
 
 impl DaemonAsyncBuilder {
@@ -99,6 +99,15 @@ impl DaemonAsyncBuilder {
         self
     }
 
+    /// Wether to write on every change of the state
+    /// If `true` - writes to a file on every change
+    /// If `false` - writes to a file when all Daemons dropped this [`DaemonState`] or [`DaemonState::force_write`] used
+    /// Defaults to `true`
+    pub fn write_on_change(&mut self, write_on_change: bool) -> &mut Self {
+        self.write_on_change = Some(write_on_change);
+        self
+    }
+
     /// Specifies path to the daemon state file
     /// Defaults to env variable.
     ///
@@ -125,6 +134,9 @@ impl DaemonAsyncBuilder {
                 let mut state = state.clone();
                 state.chain_data = chain_info.clone();
                 state.deployment_id = deployment_id;
+                if let Some(write_on_change) = self.write_on_change {
+                    state.write_on_change = write_on_change;
+                }
                 state
             }
             None => {
@@ -133,7 +145,13 @@ impl DaemonAsyncBuilder {
                     .clone()
                     .unwrap_or(DaemonState::state_file_path()?);
 
-                DaemonState::new(json_file_path, chain_info.clone(), deployment_id, false)?
+                DaemonState::new(
+                    json_file_path,
+                    chain_info.clone(),
+                    deployment_id,
+                    false,
+                    self.write_on_change.unwrap_or(true),
+                )?
             }
         };
         // if mnemonic provided, use it. Else use env variables to retrieve mnemonic
@@ -177,6 +195,7 @@ impl From<DaemonBuilder> for DaemonAsyncBuilder {
             sender: value.sender,
             state: value.state,
             state_path: value.state_path,
+            write_on_change: value.write_on_change,
         }
     }
 }

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -29,6 +29,8 @@ pub struct DaemonState {
     pub deployment_id: String,
     /// Information about the chain
     pub chain_data: ChainInfoOwned,
+    /// Wether to write on every change of the state
+    pub write_on_change: bool,
 }
 
 impl Drop for DaemonState {
@@ -59,6 +61,7 @@ impl DaemonState {
         chain_data: ChainInfoOwned,
         deployment_id: String,
         read_only: bool,
+        write_on_change: bool,
     ) -> Result<DaemonState, DaemonError> {
         let chain_id = &chain_data.chain_id;
         let chain_name = &chain_data.network_info.chain_name;
@@ -110,6 +113,7 @@ impl DaemonState {
             json_state,
             deployment_id,
             chain_data,
+            write_on_change,
         })
     }
 
@@ -189,6 +193,10 @@ impl DaemonState {
         );
         val[key][contract_id] = json!(value);
 
+        if self.write_on_change {
+            json_file_lock.force_write();
+        }
+
         Ok(())
     }
 
@@ -207,6 +215,10 @@ impl DaemonState {
             &self.chain_data.chain_id,
         );
         val[key][contract_id] = Value::Null;
+
+        if self.write_on_change {
+            json_file_lock.force_write();
+        }
 
         Ok(())
     }
@@ -236,13 +248,17 @@ impl DaemonState {
             DaemonStateFile::FullAccess { json_file_state } => json_file_state,
         };
 
-        let mut lock = json_file_state.lock().unwrap();
-        let json = lock.get_mut(
+        let mut json_file_lock = json_file_state.lock().unwrap();
+        let json = json_file_lock.get_mut(
             &self.chain_data.network_info.chain_name,
             &self.chain_data.chain_id,
         );
 
         *json = json!({});
+
+        if self.write_on_change {
+            json_file_lock.force_write();
+        }
         Ok(())
     }
 }

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -29,7 +29,7 @@ pub struct DaemonState {
     pub deployment_id: String,
     /// Information about the chain
     pub chain_data: ChainInfoOwned,
-    /// Wether to write on every change of the state
+    /// Whether to write on every change of the state
     pub write_on_change: bool,
 }
 

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -30,15 +30,15 @@ pub struct DaemonBuilder {
     pub(crate) gas_denom: Option<String>,
     pub(crate) gas_fee: Option<f64>,
     pub(crate) state_path: Option<String>,
+    /// State from rebuild or existing daemon
+    pub(crate) state: Option<DaemonState>,
+    pub(crate) write_on_change: Option<bool>,
 
     /* Sender Options */
     /// Wallet sender
     pub(crate) sender: Option<SenderBuilder<All>>,
     /// Specify Daemon Sender Options
     pub(crate) sender_options: SenderOptions,
-
-    /* Rebuilder related options */
-    pub(crate) state: Option<DaemonState>,
 }
 
 impl DaemonBuilder {
@@ -124,6 +124,15 @@ impl DaemonBuilder {
     /// Useful for multi-chain scenarios
     pub fn state(&mut self, state: DaemonState) -> &mut Self {
         self.state = Some(state);
+        self
+    }
+
+    /// Wether to write on every change of the state
+    /// If `true` - writes to a file on every change
+    /// If `false` - writes to a file when all Daemons dropped this [`DaemonState`] or [`DaemonState::force_write`] used
+    /// Defaults to `true`
+    pub fn write_on_change(&mut self, write_on_change: bool) -> &mut Self {
+        self.write_on_change = Some(write_on_change);
         self
     }
 

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -127,7 +127,7 @@ impl DaemonBuilder {
         self
     }
 
-    /// Wether to write on every change of the state
+    /// Whether to write on every change of the state
     /// If `true` - writes to a file on every change
     /// If `false` - writes to a file when all Daemons dropped this [`DaemonState`] or [`DaemonState::force_write`] used
     /// Defaults to `true`

--- a/packages/clone-testing/src/state.rs
+++ b/packages/clone-testing/src/state.rs
@@ -29,6 +29,7 @@ impl MockState {
                 chain,
                 deployment_id.to_string(),
                 true,
+                true,
             )
             .unwrap(),
         }

--- a/packages/clone-testing/src/state.rs
+++ b/packages/clone-testing/src/state.rs
@@ -29,7 +29,7 @@ impl MockState {
                 chain,
                 deployment_id.to_string(),
                 true,
-                true,
+                false,
             )
             .unwrap(),
         }


### PR DESCRIPTION
This PR aims to add write_on_change flag to DaemonState with default to `true` for auto-updating state, instead of waiting for program to finish execution
### Checklist

- [x] Changelog updated.
- [ ] Docs updated.
