### PR TITLE
Fix state reuse on a new chains

### DIFF
--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -99,11 +99,14 @@ impl DaemonState {
                 return Err(DaemonError::StateAlreadyLocked(json_file_path));
             }
             let mut json_file_state = JsonLockedState::new(&json_file_path);
-            // Insert and drop mutex lock asap
+            // Insert and drop global mutex lock asap
             lock.insert(json_file_path);
             drop(lock);
 
             json_file_state.prepare(chain_id, chain_name, &deployment_id);
+            if write_on_change {
+                json_file_state.force_write();
+            }
             DaemonStateFile::FullAccess {
                 json_file_state: Arc::new(Mutex::new(json_file_state)),
             }

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -99,7 +99,7 @@ impl DaemonState {
                 return Err(DaemonError::StateAlreadyLocked(json_file_path));
             }
             let mut json_file_state = JsonLockedState::new(&json_file_path);
-            // Insert and drop global mutex lock asap
+            // Insert file to a locked files list and drop global mutex lock asap
             lock.insert(json_file_path);
             drop(lock);
 


### PR DESCRIPTION
Just noticed that there is a bug regarding reused state. State won't be prepared for the writes if new chain is different from the previous one, unless it was prepared before.
This PR adds `state.prepare()`, if Daemon Builder uses existing state 
### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
