### PR TITLE
Upload if needed should upload if code id doesn't exist on-chain

### DIFF
--- a/packages/cw-orch-core/Cargo.toml
+++ b/packages/cw-orch-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-core"
-version = "1.1.1"
+version = "1.1.2"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/cw-orch-core/src/contract/interface_traits.rs
+++ b/packages/cw-orch-core/src/contract/interface_traits.rs
@@ -264,7 +264,7 @@ impl<T: CwOrchExecute<Chain> + ContractInstance<Chain> + Clone, Chain: TxHandler
 pub trait ConditionalUpload<Chain: CwEnv>: CwOrchUpload<Chain> {
     /// Only upload the contract if it is not uploaded yet (checksum does not match)
     fn upload_if_needed(&self) -> Result<Option<TxResponse<Chain>>, CwEnvError> {
-        if self.latest_is_uploaded()? {
+        if let Ok(true) = self.latest_is_uploaded() {
             Ok(None)
         } else {
             Some(self.upload()).transpose().map_err(Into::into)


### PR DESCRIPTION
This PR aims at correcting the upload_of_needed logic.

Previous behavior: 
- Upload the contract if it doesn't match the code_id present on-chain. IF the code_id doesn't exist on-chain, it fails

New behavior: 
- Upload the contract if it doesn't match the code_id present on-chain. IF the code_id doesn't exist on-chain, it uploads it


### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
