### PR TITLE
Re-export ibc-relayer-types used in env

### DIFF
--- a/cw-orch-interchain/Cargo.toml
+++ b/cw-orch-interchain/Cargo.toml
@@ -55,3 +55,6 @@ pretty_env_logger = "0.5.0"
 abstract-cw-orch-polytone = "2.0.0"
 abstract-polytone-note = "2.0.0"
 polytone = "1.0.0"
+
+[dependencies]
+ibc-relayer-types.workspace = true

--- a/cw-orch-interchain/src/lib.rs
+++ b/cw-orch-interchain/src/lib.rs
@@ -4,6 +4,11 @@ pub mod prelude {
     pub use cw_orch_interchain_core::{IbcQueryHandler, InterchainEnv};
     pub use cw_orch_interchain_mock::{MockBech32InterchainEnv, MockInterchainEnv};
 
+    pub use ibc_relayer_types::core::{
+        ics04_channel::packet::Sequence,
+        ics24_host::identifier::{ChannelId, PortId},
+    };
+
     #[cfg(feature = "daemon")]
     pub use cw_orch_interchain_daemon::{
         ChannelCreationValidator, ChannelCreator, DaemonInterchainEnv,


### PR DESCRIPTION
This PR aims at re-exporting the ibc-relayer-types needed inside cw-orch-interchain::env. 
This allows users to not import `ibc-relayer-types` crate when integrating and using cw-orch-interchain


### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
