### PR TITLE
Add default to min gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unpublished
 
+- `CW_ORCH_MIN_GAS` Now defaults to 150_000 instead of 0, making it more reliable for txs that cost little gas
+
+## Unpublished
+
 - Added async query functions generations with cw_orch::QueryFns
 - Re-export ibc-relayer-types inside cw-orch-interchain for ease of use
 - Deprecate cw-orch-core `TxHandler::sender` in favor of `TxHandler::sender_addr`

--- a/cw-orch-daemon/src/env.rs
+++ b/cw-orch-daemon/src/env.rs
@@ -51,13 +51,13 @@ impl DaemonEnvVars {
     }
 
     /// Optional - Integer
-    /// Defaults to None
+    /// Defaults to 150_000
     /// Minimum gas amount. Useful when transaction still won't pass even when setting a high gas_buffer or for mixed transaction scripts
-    pub fn min_gas() -> Option<u64> {
+    pub fn min_gas() -> u64 {
         if let Ok(str_value) = env::var(MIN_GAS_ENV_NAME) {
-            Some(parse_with_log(str_value, MIN_GAS_ENV_NAME))
+            parse_with_log(str_value, MIN_GAS_ENV_NAME)
         } else {
-            None
+            150_000
         }
     }
 

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -384,9 +384,9 @@ impl Wallet {
             gas as f64 * GAS_BUFFER
         };
 
-        if let Some(min_gas) = DaemonEnvVars::min_gas() {
-            gas_expected = (min_gas as f64).max(gas_expected);
-        }
+        let min_gas = DaemonEnvVars::min_gas();
+        gas_expected = (min_gas as f64).max(gas_expected);
+
         let fee_amount = gas_expected * (self.chain_info.gas_price + 0.00001);
 
         Ok((gas_expected as u64, fee_amount as u128))

--- a/cw-orch-daemon/tests/authz.rs
+++ b/cw-orch-daemon/tests/authz.rs
@@ -135,7 +135,8 @@ mod tests {
             .bank_querier()
             .balance(grantee.clone(), Some(LOCAL_JUNO.gas_denom.to_string()))?;
 
-        assert_eq!(grantee_balance.first().unwrap().amount.u128(), 600_000);
+        // One coin eaten by gas
+        assert_eq!(grantee_balance.first().unwrap().amount.u128(), 600_000 - 1);
 
         Ok(())
     }


### PR DESCRIPTION
New min gas default is 150_000 instead of 0, making it more reliable in txs that costs little gas such as bank send
### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
