### PR TITLE
Add `is_test` for daemons to use temporary files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- `is_test` Added for DaemonBuilder, to use temporary file for state instead of default
+
 ### Breaking
 
 ## 0.24.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unpublished
 
-- `is_test` Added for DaemonBuilder, to use temporary file for state instead of default
+- `is_test` Added for Daemon Builders, when set to `true` will use temporary file for state
 
 ### Breaking
 

--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -71,6 +71,9 @@ lazy_static = "1.4.0"
 file-lock = { version = "2.1.10" }
 once_cell = { version = "1.19.0" }
 
+# Tempfile names
+fastrand = "2.1.0"
+
 [dev-dependencies]
 cw-orch-daemon = { path = "." }
 cw-orch = { path = "../cw-orch", features = ["daemon"] }

--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -72,12 +72,11 @@ file-lock = { version = "2.1.10" }
 once_cell = { version = "1.19.0" }
 
 # Tempfile names
-fastrand = "2.1.0"
+uid = "0.1.7"
 
 [dev-dependencies]
 cw-orch-daemon = { path = "." }
 cw-orch = { path = "../cw-orch", features = ["daemon"] }
-uid = "0.1.7"
 env_logger = "0.11.2"
 cw20 = { version = "1" }
 cw20-base = { version = "1" }

--- a/cw-orch-daemon/src/builder.rs
+++ b/cw-orch-daemon/src/builder.rs
@@ -86,6 +86,7 @@ impl DaemonAsyncBuilder {
     }
 
     /// Set daemon as testing daemon
+    /// when set to `true` will use temporary file for state
     pub fn is_test(&mut self, is_test: bool) -> &mut Self {
         self.is_test = is_test;
         self

--- a/cw-orch-daemon/src/core.rs
+++ b/cw-orch-daemon/src/core.rs
@@ -133,6 +133,8 @@ impl<Sender> DaemonAsyncBase<Sender> {
             state_path: None,
             write_on_change: None,
             mnemonic: None,
+            // If it was test it will just use same tempfile as state
+            is_test: false,
         }
     }
 }

--- a/cw-orch-daemon/src/senders/query_only.rs
+++ b/cw-orch-daemon/src/senders/query_only.rs
@@ -46,7 +46,7 @@ impl QuerySender for QueryOnlySender {
 
 #[cfg(test)]
 mod tests {
-    use cw_orch_networks::networks::OSMOSIS_1;
+    use cw_orch_networks::networks::JUNO_1;
 
     use super::QueryOnlyDaemon;
     use crate::DaemonBuilder;
@@ -55,6 +55,6 @@ mod tests {
     #[serial_test::serial]
     fn build() {
         let _query_only_daemon: QueryOnlyDaemon =
-            DaemonBuilder::new(OSMOSIS_1).build_sender(()).unwrap();
+            DaemonBuilder::new(JUNO_1).build_sender(()).unwrap();
     }
 }

--- a/cw-orch-daemon/src/state.rs
+++ b/cw-orch-daemon/src/state.rs
@@ -8,6 +8,7 @@ use cw_orch_core::{environment::StateInterface, log::local_target, CwEnvError};
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use serde_json::{json, Value};
+use std::ffi::OsString;
 use std::sync::Arc;
 use std::{
     collections::{HashMap, HashSet},
@@ -329,6 +330,19 @@ impl StateInterface for DaemonState {
         }
         Ok(store)
     }
+}
+
+// copied from `tempfile::util::tmpname` implementation
+pub(crate) fn gen_temp_file_path() -> std::path::PathBuf {
+    let mut env_dir = std::env::temp_dir();
+    let rand_len = 8;
+    let mut file_name = OsString::with_capacity(rand_len);
+    let mut char_buf = [0u8; 4];
+    for c in std::iter::repeat_with(fastrand::alphanumeric).take(rand_len) {
+        file_name.push(c.encode_utf8(&mut char_buf));
+    }
+    env_dir.push(file_name);
+    env_dir
 }
 
 #[cfg(test)]

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -176,7 +176,7 @@ impl DaemonBuilder {
 #[cfg(test)]
 mod test {
     use cw_orch_core::environment::TxHandler;
-    use cw_orch_networks::networks::OSMOSIS_1;
+    use cw_orch_networks::networks::JUNO_1;
 
     use crate::{DaemonBase, DaemonBuilder, Wallet};
     pub const DUMMY_MNEMONIC:&str = "chapter wrist alcohol shine angry noise mercy simple rebel recycle vehicle wrap morning giraffe lazy outdoor noise blood ginger sort reunion boss crowd dutch";
@@ -184,18 +184,18 @@ mod test {
     #[test]
     #[serial_test::serial]
     fn grpc_override() {
-        let mut chain = OSMOSIS_1;
+        let mut chain = JUNO_1;
         chain.grpc_urls = &[];
         let daemon = DaemonBuilder::new(chain)
             .mnemonic(DUMMY_MNEMONIC)
-            .grpc_url(OSMOSIS_1.grpc_urls[0])
+            .grpc_url(JUNO_1.grpc_urls[0])
             .build()
             .unwrap();
 
         assert_eq!(daemon.daemon.sender().chain_info.grpc_urls.len(), 1);
         assert_eq!(
             daemon.daemon.sender().chain_info.grpc_urls[0],
-            OSMOSIS_1.grpc_urls[0].to_string(),
+            JUNO_1.grpc_urls[0].to_string(),
         );
     }
 
@@ -203,7 +203,7 @@ mod test {
     #[serial_test::serial]
     fn fee_amount_override() {
         let fee_amount = 1.3238763;
-        let daemon = DaemonBuilder::new(OSMOSIS_1)
+        let daemon = DaemonBuilder::new(JUNO_1)
             .mnemonic(DUMMY_MNEMONIC)
             .gas(None, Some(fee_amount))
             .build()
@@ -217,7 +217,7 @@ mod test {
     #[serial_test::serial]
     fn fee_denom_override() {
         let token = "my_token";
-        let daemon = DaemonBuilder::new(OSMOSIS_1)
+        let daemon = DaemonBuilder::new(JUNO_1)
             .mnemonic(DUMMY_MNEMONIC)
             .gas(Some(token), None)
             .build()
@@ -234,7 +234,7 @@ mod test {
     fn fee_override() {
         let fee_amount = 1.3238763;
         let token = "my_token";
-        let daemon = DaemonBuilder::new(OSMOSIS_1)
+        let daemon = DaemonBuilder::new(JUNO_1)
             .mnemonic(DUMMY_MNEMONIC)
             .gas(Some(token), Some(fee_amount))
             .build()
@@ -251,7 +251,7 @@ mod test {
     #[test]
     #[serial_test::serial]
     fn hd_index_re_generates_sender() -> anyhow::Result<()> {
-        let daemon = DaemonBuilder::new(OSMOSIS_1)
+        let daemon = DaemonBuilder::new(JUNO_1)
             .mnemonic(DUMMY_MNEMONIC)
             .build()
             .unwrap();

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -122,6 +122,7 @@ impl DaemonBuilder {
     }
 
     /// Set daemon as testing daemon
+    /// when set to `true` will use temporary file for state
     pub fn is_test(&mut self, is_test: bool) -> &mut Self {
         self.is_test = is_test;
         self

--- a/cw-orch-daemon/src/sync/builder.rs
+++ b/cw-orch-daemon/src/sync/builder.rs
@@ -24,9 +24,11 @@ pub struct DaemonBuilder {
     pub(crate) handle: Option<tokio::runtime::Handle>,
     pub(crate) deployment_id: Option<String>,
     pub(crate) state_path: Option<String>,
-    /// State from rebuild or existing daemon
+    // State from rebuild or existing daemon
     pub(crate) state: Option<DaemonState>,
     pub(crate) write_on_change: Option<bool>,
+    // # Use tempfile as state
+    pub(crate) is_test: bool,
 
     pub(crate) mnemonic: Option<String>,
 }
@@ -41,6 +43,7 @@ impl DaemonBuilder {
             state: None,
             write_on_change: None,
             mnemonic: None,
+            is_test: false,
         }
     }
 
@@ -115,6 +118,12 @@ impl DaemonBuilder {
     /// Overwrite the chain info
     pub fn chain(&mut self, chain: impl Into<ChainInfoOwned>) -> &mut Self {
         self.chain = chain.into();
+        self
+    }
+
+    /// Set daemon as testing daemon
+    pub fn is_test(&mut self, is_test: bool) -> &mut Self {
+        self.is_test = is_test;
         self
     }
 

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -112,6 +112,8 @@ impl<Sender: QuerySender> DaemonBase<Sender> {
             write_on_change: None,
             handle: Some(self.rt_handle.clone()),
             mnemonic: None,
+            // If it was test it will just use same tempfile as state
+            is_test: false,
         }
     }
 }

--- a/cw-orch-daemon/tests/authz.rs
+++ b/cw-orch-daemon/tests/authz.rs
@@ -24,11 +24,13 @@ mod tests {
     pub const SECOND_MNEMONIC: &str ="salute trigger antenna west ignore own dance bounce battle soul girl scan test enroll luggage sorry distance traffic brand keen rich syrup wood repair";
 
     #[test]
-    #[serial_test::serial]
     fn authz() -> anyhow::Result<()> {
         use cw_orch_networks::networks;
 
-        let daemon = Daemon::builder(networks::LOCAL_JUNO).build().unwrap();
+        let daemon = Daemon::builder(networks::LOCAL_JUNO)
+            .is_test(true)
+            .build()
+            .unwrap();
 
         let sender = daemon.sender_addr().to_string();
 

--- a/cw-orch-daemon/tests/authz.rs
+++ b/cw-orch-daemon/tests/authz.rs
@@ -24,6 +24,7 @@ mod tests {
     pub const SECOND_MNEMONIC: &str ="salute trigger antenna west ignore own dance bounce battle soul girl scan test enroll luggage sorry distance traffic brand keen rich syrup wood repair";
 
     #[test]
+    #[serial_test::serial]
     fn authz() -> anyhow::Result<()> {
         use cw_orch_networks::networks;
 

--- a/cw-orch-daemon/tests/common/mod.rs
+++ b/cw-orch-daemon/tests/common/mod.rs
@@ -20,14 +20,6 @@ mod node {
     // From https://github.com/CosmosContracts/juno/blob/32568dba828ff7783aea8cb5bb4b8b5832888255/docker/test-user.env#L2
     const LOCAL_MNEMONIC: &str = "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose";
 
-    use uid::Id as IdT;
-
-    #[derive(Copy, Clone, Eq, PartialEq)]
-    pub struct DeployId(());
-
-    #[allow(unused)]
-    pub type Id = IdT<DeployId>;
-
     pub mod state_file {
         use super::{fs, Path};
 

--- a/cw-orch-daemon/tests/common/mod.rs
+++ b/cw-orch-daemon/tests/common/mod.rs
@@ -180,7 +180,9 @@ mod node {
         container::ensure_removal(&env::var("CONTAINER_NAME").unwrap());
         let temp_dir = env::temp_dir();
         let expected_state_file = temp_dir.join("cw_orch_test_local.json");
-        state_file::remove(expected_state_file.to_str().unwrap());
+        if let Some(state_file) = expected_state_file.to_str() {
+            state_file::remove(state_file);
+        }
     }
 
     #[ctor]

--- a/cw-orch-daemon/tests/daemon_helpers.rs
+++ b/cw-orch-daemon/tests/daemon_helpers.rs
@@ -13,8 +13,6 @@ mod tests {
 
     use speculoos::prelude::*;
 
-    use crate::common::Id;
-
     #[test]
     #[serial_test::serial]
     fn helper_traits() {
@@ -29,10 +27,7 @@ mod tests {
 
         let sender = daemon.sender_addr();
 
-        let contract = mock_contract::MockContract::new(
-            format!("test:mock_contract:{}", Id::new()),
-            daemon.clone(),
-        );
+        let contract = mock_contract::MockContract::new("test:mock_contract", daemon.clone());
 
         asserting!("address is not present")
             .that(&contract.address())
@@ -101,10 +96,7 @@ mod tests {
 
         let sender = daemon.sender_addr();
 
-        let contract = mock_contract::MockContract::new(
-            format!("test:mock_contract:{}", Id::new()),
-            daemon.clone(),
-        );
+        let contract = mock_contract::MockContract::new("test:mock_contract", daemon.clone());
 
         // upload contract
         let upload_res = contract.upload();

--- a/cw-orch-daemon/tests/daemon_helpers.rs
+++ b/cw-orch-daemon/tests/daemon_helpers.rs
@@ -20,7 +20,10 @@ mod tests {
     fn helper_traits() {
         use cw_orch_networks::networks;
 
-        let mut daemon = Daemon::builder(networks::LOCAL_JUNO).build().unwrap();
+        let mut daemon = Daemon::builder(networks::LOCAL_JUNO)
+            .is_test(true)
+            .build()
+            .unwrap();
 
         daemon.flush_state().unwrap();
 
@@ -91,7 +94,10 @@ mod tests {
     fn cw_orch_interface_traits() {
         use cw_orch_networks::networks;
 
-        let daemon = Daemon::builder(networks::LOCAL_JUNO).build().unwrap();
+        let daemon = Daemon::builder(networks::LOCAL_JUNO)
+            .is_test(true)
+            .build()
+            .unwrap();
 
         let sender = daemon.sender_addr();
 

--- a/cw-orch-daemon/tests/daemon_state.rs
+++ b/cw-orch-daemon/tests/daemon_state.rs
@@ -3,21 +3,18 @@ use std::sync::Arc;
 use cw_orch_core::environment::ChainState;
 use cw_orch_daemon::{
     env::STATE_FILE_ENV_NAME,
-    json_lock::JsonLockedState,
-    networks::{JUNO_1, OSMOSIS_1},
+    networks::{JUNO_1, NEUTRON_1},
     Daemon, DaemonBuilder, DaemonError, DaemonStateFile,
 };
 
 pub const DUMMY_MNEMONIC:&str = "chapter wrist alcohol shine angry noise mercy simple rebel recycle vehicle wrap morning giraffe lazy outdoor noise blood ginger sort reunion boss crowd dutch";
-const TEST_STATE_FILE: &str = "./tests/test.json";
-const TEST2_STATE_FILE: &str = "./tests/test2.json";
 
 #[test]
 #[serial_test::serial]
 fn simultaneous_read() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-    let daemon = DaemonBuilder::new(OSMOSIS_1)
+    let daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build()
         .unwrap();
 
@@ -58,9 +55,9 @@ fn simultaneous_read() {
 #[test]
 #[serial_test::serial]
 fn simultaneous_write() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-    let daemon = DaemonBuilder::new(OSMOSIS_1)
+    let daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build()
         .unwrap();
 
@@ -98,9 +95,9 @@ fn simultaneous_write() {
 #[test]
 #[serial_test::serial]
 fn simultaneous_write_rebuilt() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-    let daemon = DaemonBuilder::new(OSMOSIS_1)
+    let daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build()
         .unwrap();
 
@@ -142,15 +139,17 @@ fn simultaneous_write_rebuilt() {
 #[test]
 #[serial_test::serial]
 fn error_when_another_daemon_holds_it() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-    let _daemon = DaemonBuilder::new(OSMOSIS_1)
+    let state_path = std::env::temp_dir()
+        .join("daemon_state_test_file")
+        .into_os_string();
+    std::env::set_var(STATE_FILE_ENV_NAME, state_path);
+
+    let _daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
         .build()
         .unwrap();
 
-    let daemon_res = DaemonBuilder::new(OSMOSIS_1)
-        .mnemonic(DUMMY_MNEMONIC)
-        .build();
+    let daemon_res = DaemonBuilder::new(JUNO_1).mnemonic(DUMMY_MNEMONIC).build();
 
     assert!(matches!(
         daemon_res,
@@ -162,16 +161,17 @@ fn error_when_another_daemon_holds_it() {
 #[test]
 #[serial_test::serial]
 fn does_not_error_when_previous_daemon_dropped_state() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-    let daemon = DaemonBuilder::new(OSMOSIS_1)
+    let daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build()
         .unwrap();
 
     drop(daemon);
 
-    let daemon_res = DaemonBuilder::new(OSMOSIS_1)
+    let daemon_res = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build();
 
     assert!(daemon_res.is_ok());
@@ -181,16 +181,17 @@ fn does_not_error_when_previous_daemon_dropped_state() {
 #[test]
 #[serial_test::serial]
 fn does_not_error_when_using_different_files() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-    let _daemon = DaemonBuilder::new(OSMOSIS_1)
+    let _daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build()
         .unwrap();
 
     // Different file
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST2_STATE_FILE);
-    let daemon_res = DaemonBuilder::new(OSMOSIS_1)
+    let daemon_res = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        // is test will produce new file every time
+        .is_test(true)
         .build();
 
     assert!(daemon_res.is_ok());
@@ -200,14 +201,13 @@ fn does_not_error_when_using_different_files() {
 #[test]
 #[serial_test::serial]
 fn reuse_same_state_multichain() {
-    std::env::set_var(STATE_FILE_ENV_NAME, TEST_STATE_FILE);
-
-    let daemon = DaemonBuilder::new(OSMOSIS_1)
+    let daemon = DaemonBuilder::new(JUNO_1)
         .mnemonic(DUMMY_MNEMONIC)
+        .is_test(true)
         .build()
         .unwrap();
 
-    let daemon_res = DaemonBuilder::new(JUNO_1)
+    let daemon_res = DaemonBuilder::new(NEUTRON_1)
         .state(daemon.state())
         .mnemonic(DUMMY_MNEMONIC)
         .build();
@@ -216,22 +216,22 @@ fn reuse_same_state_multichain() {
     std::env::remove_var(STATE_FILE_ENV_NAME);
 }
 
-#[test]
-#[serial_test::serial]
-#[should_panic]
-#[ignore = "Serial don't track forks for some reason, run it manually"]
-fn panic_when_someone_holds_json_file() {
-    match unsafe { nix::unistd::fork() } {
-        Ok(nix::unistd::ForkResult::Child) => {
-            // Occur lock for file for 100 millis
-            let _state = JsonLockedState::new(TEST_STATE_FILE);
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-        Ok(nix::unistd::ForkResult::Parent { .. }) => {
-            // Wait a bit for child to occur lock and try to lock already locked file by child
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            let _state = JsonLockedState::new(TEST_STATE_FILE);
-        }
-        Err(_) => (),
-    }
-}
+// #[test]
+// #[serial_test::serial]
+// #[should_panic]
+// #[ignore = "Serial don't track forks for some reason, run it manually"]
+// fn panic_when_someone_holds_json_file() {
+//     match unsafe { nix::unistd::fork() } {
+//         Ok(nix::unistd::ForkResult::Child) => {
+//             // Occur lock for file for 100 millis
+//             let _state = JsonLockedState::new(TEST_STATE_FILE);
+//             std::thread::sleep(std::time::Duration::from_millis(100));
+//         }
+//         Ok(nix::unistd::ForkResult::Parent { .. }) => {
+//             // Wait a bit for child to occur lock and try to lock already locked file by child
+//             std::thread::sleep(std::time::Duration::from_millis(50));
+//             let _state = JsonLockedState::new(TEST_STATE_FILE);
+//         }
+//         Err(_) => (),
+//     }
+// }

--- a/cw-orch-daemon/tests/index.rs
+++ b/cw-orch-daemon/tests/index.rs
@@ -10,7 +10,10 @@ mod tests {
     fn mnemonic_index() -> anyhow::Result<()> {
         use cw_orch_networks::networks;
 
-        let daemon = Daemon::builder(networks::LOCAL_JUNO).build().unwrap();
+        let daemon = Daemon::builder(networks::LOCAL_JUNO)
+            .is_test(true)
+            .build()
+            .unwrap();
 
         let daemon_sender = daemon.sender_addr().to_string();
         let indexed_daemon: Daemon = daemon

--- a/cw-orch-daemon/tests/instantiate2.rs
+++ b/cw-orch-daemon/tests/instantiate2.rs
@@ -15,7 +15,10 @@ pub mod test {
     #[test]
     #[serial_test::serial]
     fn instantiate2() -> anyhow::Result<()> {
-        let app = Daemon::builder(networks::LOCAL_JUNO).build().unwrap();
+        let app = Daemon::builder(networks::LOCAL_JUNO)
+            .is_test(true)
+            .build()
+            .unwrap();
 
         let salt = Binary(vec![12, 89, 156, 63]);
         let mock_contract = MockContract::new("mock-contract", app.clone());

--- a/cw-orch-daemon/tests/querier.rs
+++ b/cw-orch-daemon/tests/querier.rs
@@ -206,7 +206,6 @@ mod queriers {
     #[test]
     #[serial_test::serial]
     fn contract_info() {
-        use crate::common::Id;
         use cw_orch_daemon::TxSender;
         use cw_orch_networks::networks;
 
@@ -220,10 +219,7 @@ mod queriers {
 
         let sender = daemon.sender();
 
-        let contract = mock_contract::MockContract::new(
-            format!("test:mock_contract:{}", Id::new()),
-            daemon.clone(),
-        );
+        let contract = mock_contract::MockContract::new("test:mock_contract", daemon.clone());
 
         contract.upload().unwrap();
 

--- a/cw-orch-daemon/tests/querier.rs
+++ b/cw-orch-daemon/tests/querier.rs
@@ -213,7 +213,10 @@ mod queriers {
         let rt = Runtime::new().unwrap();
         let channel = rt.block_on(build_channel());
         let cosm_wasm = CosmWasm::new_async(channel);
-        let daemon = Daemon::builder(networks::LOCAL_JUNO).build().unwrap();
+        let daemon = Daemon::builder(networks::LOCAL_JUNO)
+            .is_test(true)
+            .build()
+            .unwrap();
 
         let sender = daemon.sender();
 


### PR DESCRIPTION
Randomly generated name for temporary file inside tempdir of OS will be used when `is_test` provided for daemons, this file will be removed by OS when no longer needed

### Checklist

- [x] Changelog updated.
- [ ] Docs updated.
