### PR TITLE
Re-use contract's WASM compilation

### DIFF
--- a/packages/clone-testing/Cargo.toml
+++ b/packages/clone-testing/Cargo.toml
@@ -17,7 +17,8 @@ cw-orch-core = { version = "2.0.0" }
 cw-orch-mock = { version = "0.24.0" }
 cw-orch-daemon = { version = "0.25.0" }
 
-clone-cw-multi-test = { version = "0.6.0-alpha.1" }
+# clone-cw-multi-test = { version = "0.6.0-alpha.1" }
+clone-cw-multi-test = { git = "https://github.com/AbstractSDK/cw-multi-test-fork", branch = "nicolas/orc-161-re-use-contracts-wasm-compilation" }
 
 
 cw-utils = { workspace = true }

--- a/packages/clone-testing/src/core.rs
+++ b/packages/clone-testing/src/core.rs
@@ -155,10 +155,7 @@ impl CloneTesting {
         let mut file = std::fs::File::open(T::wasm(&self.chain).path())?;
         let mut wasm = Vec::<u8>::new();
         file.read_to_end(&mut wasm)?;
-        let code_id = self
-            .app
-            .borrow_mut()
-            .store_wasm_code(WasmContract::Local(LocalWasmContract { code: wasm }));
+        let code_id = self.app.borrow_mut().store_wasm_code(wasm);
 
         contract.set_code_id(code_id);
 

--- a/packages/clone-testing/src/core.rs
+++ b/packages/clone-testing/src/core.rs
@@ -2,11 +2,7 @@ use std::{cell::RefCell, fmt::Debug, io::Read, rc::Rc};
 
 use clone_cw_multi_test::{
     addons::{MockAddressGenerator, MockApiBech32},
-    wasm_emulation::{
-        channel::RemoteChannel,
-        contract::{LocalWasmContract, WasmContract},
-        storage::analyzer::StorageAnalyzer,
-    },
+    wasm_emulation::{channel::RemoteChannel, storage::analyzer::StorageAnalyzer},
     App, AppBuilder, BankKeeper, Contract, Executor, WasmKeeper,
 };
 use cosmwasm_std::{to_json_binary, WasmMsg};


### PR DESCRIPTION
This PR introduces caching of wasm compiled modules to speed up the execution.

When using a wasm file, we compile it and save it inside the app for later use. 

This is possible everywhere except during in-contract queries. When using a contract inside an in-contract query, it doesn't get saved into memory.

Depends on (where all the changes are located) : https://github.com/AbstractSDK/cw-multi-test-fork/pull/8

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
