### PR TITLE
Allow setting private key for sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+ - Add methods to set the private key and mnemonic of an existing sender
+  
 ### Breaking
 
 ## 0.25.0

--- a/cw-orch-daemon/src/env.rs
+++ b/cw-orch-daemon/src/env.rs
@@ -1,4 +1,6 @@
-//! This regroups all env variables used by cw-orch-daemon. It allows for easier documentation and env variable management
+//! This regroups all env variables used by cw-orch-daemon.
+//!
+//! It allows for easier documentation and env variable management
 //! This is used to import environment variables with safe names (and at a centralized location)
 //! To get the env variable parsed value, you can use
 //! ```rust,no_run

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -149,7 +149,7 @@ impl Wallet {
     }
 
     /// Replaces the private key the sender is using
-    /// If you only need to change the mnemonic, use [Self::set_mnemonic]
+    /// You can use a mnemonic to overwrite the key using [Self::set_mnemonic]
     pub fn set_private_key(&mut self, private_key: PrivateKey) {
         self.private_key = private_key
     }

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -132,6 +132,24 @@ impl Wallet {
         self.options.clone()
     }
 
+    pub fn set_mnemonic(&mut self, mnemonic: impl Into<String>) -> Result<(), DaemonError> {
+        let secp = Secp256k1::new();
+
+        let pk = PrivateKey::from_words(
+            &secp,
+            &mnemonic.into(),
+            0,
+            self.options.hd_index.unwrap_or(0),
+            self.chain_info.network_info.coin_type,
+        )?;
+        self.set_private_key(pk);
+        Ok(())
+    }
+
+    pub fn set_private_key(&mut self, private_key: PrivateKey) {
+        self.private_key = private_key
+    }
+
     pub fn set_authz_granter(&mut self, granter: &Addr) {
         self.options.authz_granter = Some(granter.to_owned());
     }

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -132,6 +132,8 @@ impl Wallet {
         self.options.clone()
     }
 
+    /// Replaces the private key that the [CosmosSender] is using with the provided mnemonic string.
+    /// If you want more control over the derived private key, use [Self::set_private_key]
     pub fn set_mnemonic(&mut self, mnemonic: impl Into<String>) -> Result<(), DaemonError> {
         let secp = Secp256k1::new();
 
@@ -146,6 +148,8 @@ impl Wallet {
         Ok(())
     }
 
+    /// Replaces the private key the sender is using
+    /// If you only need to change the mnemonic, use [Self::set_mnemonic]
     pub fn set_private_key(&mut self, private_key: PrivateKey) {
         self.private_key = private_key
     }

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -132,7 +132,7 @@ impl Wallet {
         self.options.clone()
     }
 
-    /// Replaces the private key that the [CosmosSender] is using with the provided mnemonic string.
+    /// Replaces the private key that the [CosmosSender] is using with key derived from the provided 24-word mnemonic.
     /// If you want more control over the derived private key, use [Self::set_private_key]
     pub fn set_mnemonic(&mut self, mnemonic: impl Into<String>) -> Result<(), DaemonError> {
         let secp = Secp256k1::new();

--- a/packages/cw-orch-core/src/env.rs
+++ b/packages/cw-orch-core/src/env.rs
@@ -1,4 +1,6 @@
-//! This regroups all env variables used by cw-orch-daemon. It allows for easier documentation and env variable management
+//! This regroups all env variables used by cw-orch-daemon.
+//!
+//! It allows for easier documentation and env variable management
 //! This is used to import environment variables with safe names (and at a centralized location)
 //! To get the env variable parsed value, you can use
 //! ```rust,no_run


### PR DESCRIPTION
This PR aims at allowing setting the private key or the mnemonic for the CosmosSender object

### Checklist

- [x] Changelog updated.
- [x] Docs updated.
