### PR TITLE
Replace Cw-Multi-Test wiith official version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,6 @@ cosmwasm-std = { version = "2.1" }
 cw-storage-plus = { version = "2.0.0" }
 cosmos-sdk-proto = { version = "0.24.0", default-features = false }
 
-# cw-multi-test = { package = "abstract-cw-multi-test", version = "2.0.2", features = [
-#   "cosmwasm_1_2",
-# ] }
 cw-multi-test = { git = "https://github.com/cosmwasm/cw-multi-test", tag = "v3.0.0-ibc-alpha.0", features = [
   "staking",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,11 @@ cosmwasm-std = { version = "2.1" }
 cw-storage-plus = { version = "2.0.0" }
 cosmos-sdk-proto = { version = "0.24.0", default-features = false }
 
-cw-multi-test = { package = "abstract-cw-multi-test", version = "2.0.2", features = [
-  "cosmwasm_1_2",
+# cw-multi-test = { package = "abstract-cw-multi-test", version = "2.0.2", features = [
+#   "cosmwasm_1_2",
+# ] }
+cw-multi-test = { git = "https://github.com/cosmwasm/cw-multi-test", tag = "v3.0.0-ibc-alpha.0", features = [
+  "staking",
 ] }
 cw20 = { package = "abstract-cw20", version = "3.0.0" }
 cw20-base = { package = "abstract-cw20-base", version = "3.0.0" }


### PR DESCRIPTION
This PR aims at removing the dependency of our fork of cw-multi-test and moving it to the official cw-multi-test.

This is still a draft because we are waiting for cw-multi-test to stabilize version 3.0.0

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
