### PR TITLE
Added CosmosSigner default implementation

### DIFF
--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -1,4 +1,9 @@
-use super::{cosmos_options::CosmosWalletKey, query::QuerySender, tx::TxSender};
+use super::{
+    cosmos_options::CosmosWalletKey,
+    query::QuerySender,
+    sign::{CosmosSigner, SigningAccount},
+    tx::TxSender,
+};
 use crate::{
     core::parse_cw_coins,
     cosmos_modules::{self, auth::BaseAccount},
@@ -7,10 +12,6 @@ use crate::{
     keys::private::PrivateKey,
     proto::injective::{InjectiveEthAccount, ETHEREUM_COIN_TYPE},
     queriers::{Bank, Node},
-    tx_broadcaster::{
-        account_sequence_strategy, assert_broadcast_code_cosm_response, insufficient_fee_strategy,
-        TxBroadcaster,
-    },
     tx_builder::TxBuilder,
     tx_resp::CosmTxResponse,
     upload_wasm, CosmosOptions, GrpcChannel,
@@ -20,9 +21,9 @@ use cosmos_modules::vesting::PeriodicVestingAccount;
 use cosmrs::{
     bank::MsgSend,
     crypto::secp256k1::SigningKey,
-    proto::{cosmos::authz::v1beta1::MsgExec, traits::Message},
+    proto::traits::Message,
     tendermint::chain::Id,
-    tx::{self, ModeInfo, Msg, Raw, SignDoc, SignMode, SignerInfo},
+    tx::{self, Fee, ModeInfo, Msg, Raw, SignDoc, SignMode, SignerInfo},
     AccountId, Any,
 };
 use cosmwasm_std::{coin, Addr, Coin};
@@ -158,22 +159,6 @@ impl Wallet {
         self.account_id().to_string()
     }
 
-    pub async fn broadcast_tx(
-        &self,
-        tx: Raw,
-    ) -> Result<cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse, DaemonError> {
-        let mut client = cosmos_modules::tx::service_client::ServiceClient::new(self.channel());
-        let commit = client
-            .broadcast_tx(cosmos_modules::tx::BroadcastTxRequest {
-                tx_bytes: tx.to_bytes()?,
-                mode: cosmos_modules::tx::BroadcastMode::Sync.into(),
-            })
-            .await?;
-
-        let commit = commit.into_inner().tx_response.unwrap();
-        Ok(commit)
-    }
-
     pub async fn bank_send(
         &self,
         recipient: &Addr,
@@ -267,21 +252,6 @@ impl Wallet {
             .unwrap();
 
         self.commit_tx_any(msgs, memo).await
-    }
-
-    pub fn sign(&self, sign_doc: SignDoc) -> Result<Raw, DaemonError> {
-        let tx_raw = if self.private_key.coin_type == ETHEREUM_COIN_TYPE {
-            #[cfg(not(feature = "eth"))]
-            panic!(
-                "Coin Type {} not supported without eth feature",
-                ETHEREUM_COIN_TYPE
-            );
-            #[cfg(feature = "eth")]
-            self.private_key.sign_injective(sign_doc)?
-        } else {
-            sign_doc.sign(&self.cosmos_private_key())?
-        };
-        Ok(tx_raw)
     }
 
     pub async fn base_account(&self) -> Result<BaseAccount, DaemonError> {
@@ -433,59 +403,6 @@ impl QuerySender for Wallet {
     }
 }
 
-impl TxSender for Wallet {
-    async fn commit_tx_any(
-        &self,
-        msgs: Vec<Any>,
-        memo: Option<&str>,
-    ) -> Result<CosmTxResponse, DaemonError> {
-        let timeout_height = Node::new_async(self.channel())._block_height().await? + 10u64;
-
-        let msgs = if self.options.authz_granter.is_some() {
-            // We wrap authz messages
-            vec![Any {
-                type_url: "/cosmos.authz.v1beta1.MsgExec".to_string(),
-                value: MsgExec {
-                    grantee: self.pub_addr_str(),
-                    msgs,
-                }
-                .encode_to_vec(),
-            }]
-        } else {
-            msgs
-        };
-
-        let tx_body = TxBuilder::build_body(msgs, memo, timeout_height);
-
-        let tx_builder = TxBuilder::new(tx_body);
-
-        // We retry broadcasting the tx, with the following strategies
-        // 1. In case there is an `incorrect account sequence` error, we can retry as much as possible (doesn't cost anything to the user)
-        // 2. In case there is an insufficient_fee error, we retry once (costs fee to the user everytime we submit this kind of tx)
-        // 3. In case there is an other error, we fail
-        let tx_response = TxBroadcaster::default()
-            .add_strategy(insufficient_fee_strategy())
-            .add_strategy(account_sequence_strategy())
-            .broadcast(tx_builder, self)
-            .await?;
-
-        let resp = Node::new_async(self.channel())
-            ._find_tx(tx_response.txhash)
-            .await?;
-
-        assert_broadcast_code_cosm_response(resp)
-    }
-
-    fn account_id(&self) -> AccountId {
-        AccountId::new(
-            &self.chain_info.network_info.pub_address_prefix,
-            &self.private_key.public_key(&self.secp).raw_address.unwrap(),
-        )
-        // unwrap as address is validated on construction
-        .unwrap()
-    }
-}
-
 fn get_mnemonic_env(chain_kind: &ChainKind) -> Result<String, CwEnvError> {
     match chain_kind {
         ChainKind::Local => DaemonEnvVars::local_mnemonic(),
@@ -504,5 +421,73 @@ fn get_mnemonic_env_name(chain_kind: &ChainKind) -> &str {
         ChainKind::Testnet => TEST_MNEMONIC_ENV_NAME,
         ChainKind::Mainnet => MAIN_MNEMONIC_ENV_NAME,
         _ => panic!("Can't set mnemonic for unspecified chainkind"),
+    }
+}
+
+impl CosmosSigner for Wallet {
+    fn sign(&self, sign_doc: SignDoc) -> Result<Raw, DaemonError> {
+        let tx_raw = if self.private_key.coin_type == ETHEREUM_COIN_TYPE {
+            #[cfg(not(feature = "eth"))]
+            panic!(
+                "Coin Type {} not supported without eth feature",
+                ETHEREUM_COIN_TYPE
+            );
+            #[cfg(feature = "eth")]
+            self.private_key.sign_injective(sign_doc)?
+        } else {
+            sign_doc.sign(&self.cosmos_private_key())?
+        };
+        Ok(tx_raw)
+    }
+
+    fn chain_id(&self) -> String {
+        self.chain_info.chain_id.clone()
+    }
+
+    fn signer_info(&self, sequence: u64) -> SignerInfo {
+        SignerInfo {
+            public_key: self.private_key.get_signer_public_key(&self.secp),
+            mode_info: ModeInfo::single(SignMode::Direct),
+            sequence,
+        }
+    }
+
+    fn build_fee(&self, amount: impl Into<u128>, gas_limit: u64) -> Result<Fee, DaemonError> {
+        TxBuilder::build_fee(
+            amount,
+            &self.get_fee_token(),
+            gas_limit,
+            self.options.fee_granter.clone(),
+        )
+    }
+
+    async fn signing_account(&self) -> Result<super::sign::SigningAccount, DaemonError> {
+        let BaseAccount {
+            account_number,
+            sequence,
+            ..
+        } = self.base_account().await?;
+
+        Ok(SigningAccount {
+            account_number,
+            sequence,
+        })
+    }
+
+    fn gas_price(&self) -> Result<f64, DaemonError> {
+        Ok(self.chain_info.gas_price)
+    }
+
+    fn _account_id(&self) -> AccountId {
+        AccountId::new(
+            &self.chain_info.network_info.pub_address_prefix,
+            &self.private_key.public_key(&self.secp).raw_address.unwrap(),
+        )
+        // unwrap as address is validated on construction
+        .unwrap()
+    }
+
+    fn has_authz(&self) -> bool {
+        self.options.authz_granter.is_some()
     }
 }

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -156,7 +156,7 @@ impl Wallet {
     }
 
     pub fn pub_addr_str(&self) -> String {
-        self.account_id().to_string()
+        Signer::account_id(self).to_string()
     }
 
     pub async fn bank_send(
@@ -167,7 +167,7 @@ impl Wallet {
         let acc_id = if let Some(granter) = self.options.authz_granter.as_ref() {
             AccountId::from_str(granter.as_str()).unwrap()
         } else {
-            self.account_id()
+            Signer::account_id(self)
         };
 
         let msg_send = MsgSend {
@@ -478,7 +478,7 @@ impl Signer for Wallet {
         Ok(self.chain_info.gas_price)
     }
 
-    fn _account_id(&self) -> AccountId {
+    fn account_id(&self) -> AccountId {
         AccountId::new(
             &self.chain_info.network_info.pub_address_prefix,
             &self.private_key.public_key(&self.secp).raw_address.unwrap(),

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -1,7 +1,7 @@
 use super::{
     cosmos_options::CosmosWalletKey,
     query::QuerySender,
-    sign::{CosmosSigner, SigningAccount},
+    sign::{Signer, SigningAccount},
     tx::TxSender,
 };
 use crate::{
@@ -424,7 +424,7 @@ fn get_mnemonic_env_name(chain_kind: &ChainKind) -> &str {
     }
 }
 
-impl CosmosSigner for Wallet {
+impl Signer for Wallet {
     fn sign(&self, sign_doc: SignDoc) -> Result<Raw, DaemonError> {
         let tx_raw = if self.private_key.coin_type == ETHEREUM_COIN_TYPE {
             #[cfg(not(feature = "eth"))]

--- a/cw-orch-daemon/src/senders/mod.rs
+++ b/cw-orch-daemon/src/senders/mod.rs
@@ -1,6 +1,7 @@
 // Core Sender traits
 pub mod builder;
 pub mod query;
+pub mod sign;
 pub mod tx;
 
 // Senders

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -1,5 +1,4 @@
 use crate::{
-    cosmos_modules,
     queriers::Node,
     tx_broadcaster::{
         account_sequence_strategy, assert_broadcast_code_cosm_response, insufficient_fee_strategy,
@@ -20,7 +19,7 @@ pub struct SigningAccount {
     pub sequence: u64,
 }
 
-pub trait CosmosSigner: QuerySender<Error = DaemonError> + Sync {
+pub trait Signer: QuerySender<Error = DaemonError> + Sync {
     // --- General information about the signer --- //
     /// The chain id of the connected chain
     fn chain_id(&self) -> String;
@@ -75,7 +74,7 @@ pub trait CosmosSigner: QuerySender<Error = DaemonError> + Sync {
     }
 }
 
-impl<T: CosmosSigner + Sync> TxSender for T {
+impl<T: Signer + Sync> TxSender for T {
     fn account_id(&self) -> cosmrs::AccountId {
         self._account_id()
     }

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -73,26 +73,6 @@ pub trait CosmosSigner: QuerySender<Error = DaemonError> + Sync {
                 .await
         }
     }
-    /// Transaction broadcasting for Tendermint Transactions
-    fn broadcast_tx(
-        &self,
-        tx: Raw,
-    ) -> impl std::future::Future<
-        Output = Result<cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse, DaemonError>,
-    > + Send {
-        async move {
-            let mut client = cosmos_modules::tx::service_client::ServiceClient::new(self.channel());
-            let commit = client
-                .broadcast_tx(cosmos_modules::tx::BroadcastTxRequest {
-                    tx_bytes: tx.to_bytes()?,
-                    mode: cosmos_modules::tx::BroadcastMode::Sync.into(),
-                })
-                .await?;
-
-            let commit = commit.into_inner().tx_response.unwrap();
-            Ok(commit)
-        }
-    }
 }
 
 impl<T: CosmosSigner + Sync> TxSender for T {

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -25,7 +25,7 @@ pub trait Signer: QuerySender<Error = DaemonError> + Sync {
     fn chain_id(&self) -> String;
 
     /// The account id of the signer.
-    /// This is `_` prefixed because this conflict wih the TxSender trat
+    /// This is `_` prefixed because this conflict wih the TxSender trait
     fn _account_id(&self) -> AccountId;
 
     fn signing_account(
@@ -34,7 +34,9 @@ pub trait Signer: QuerySender<Error = DaemonError> + Sync {
 
     /// Signals wether this signer is using authz
     /// If set to true, the signed messages will be wrapped inside authz messages
-    fn has_authz(&self) -> bool;
+    fn has_authz(&self) -> bool {
+        false
+    }
 
     // --- Related to transaction signing --- //
     /// Transaction signing

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -1,0 +1,145 @@
+use crate::{
+    cosmos_modules,
+    queriers::Node,
+    tx_broadcaster::{
+        account_sequence_strategy, assert_broadcast_code_cosm_response, insufficient_fee_strategy,
+        TxBroadcaster,
+    },
+    CosmTxResponse, DaemonError, QuerySender, TxBuilder, TxSender,
+};
+use cosmrs::{
+    proto::cosmos::authz::v1beta1::MsgExec,
+    tendermint::chain::Id,
+    tx::{Body, Fee, Raw, SignDoc, SignerInfo},
+    AccountId, Any,
+};
+use prost::Message;
+
+pub struct SigningAccount {
+    pub account_number: u64,
+    pub sequence: u64,
+}
+
+pub trait CosmosSigner: QuerySender<Error = DaemonError> + Sync {
+    // --- General information about the signer --- //
+    /// The chain id of the connected chain
+    fn chain_id(&self) -> String;
+
+    /// The account id of the signer.
+    /// This is `_` prefixed because this conflict wih the TxSender trat
+    fn _account_id(&self) -> AccountId;
+
+    fn signing_account(
+        &self,
+    ) -> impl std::future::Future<Output = Result<SigningAccount, DaemonError>> + Send;
+
+    /// Signals wether this signer is using authz
+    /// If set to true, the signed messages will be wrapped inside authz messages
+    fn has_authz(&self) -> bool;
+
+    // --- Related to transaction signing --- //
+    /// Transaction signing
+    fn sign(&self, sign_doc: SignDoc) -> Result<Raw, DaemonError>;
+
+    fn signer_info(&self, sequence: u64) -> SignerInfo;
+
+    fn build_fee(&self, amount: impl Into<u128>, gas_limit: u64) -> Result<Fee, DaemonError>;
+
+    fn gas_price(&self) -> Result<f64, DaemonError>;
+
+    /// Computes the gas needed for submitting a transaction
+    fn calculate_gas(
+        &self,
+        tx_body: &Body,
+        sequence: u64,
+        account_number: u64,
+    ) -> impl std::future::Future<Output = Result<u64, DaemonError>> + Send {
+        async move {
+            let fee = self.build_fee(0u8, 0)?;
+
+            let auth_info = self.signer_info(sequence).auth_info(fee);
+
+            let sign_doc = SignDoc::new(
+                tx_body,
+                &auth_info,
+                &Id::try_from(self.chain_id())?,
+                account_number,
+            )?;
+
+            let tx_raw = self.sign(sign_doc)?;
+
+            Node::new_async(self.channel())
+                ._simulate_tx(tx_raw.to_bytes()?)
+                .await
+        }
+    }
+    /// Transaction broadcasting for Tendermint Transactions
+    fn broadcast_tx(
+        &self,
+        tx: Raw,
+    ) -> impl std::future::Future<
+        Output = Result<cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse, DaemonError>,
+    > + Send {
+        async move {
+            let mut client = cosmos_modules::tx::service_client::ServiceClient::new(self.channel());
+            let commit = client
+                .broadcast_tx(cosmos_modules::tx::BroadcastTxRequest {
+                    tx_bytes: tx.to_bytes()?,
+                    mode: cosmos_modules::tx::BroadcastMode::Sync.into(),
+                })
+                .await?;
+
+            let commit = commit.into_inner().tx_response.unwrap();
+            Ok(commit)
+        }
+    }
+}
+
+impl<T: CosmosSigner + Sync> TxSender for T {
+    fn account_id(&self) -> cosmrs::AccountId {
+        self._account_id()
+    }
+
+    async fn commit_tx_any(
+        &self,
+        msgs: Vec<Any>,
+        memo: Option<&str>,
+    ) -> Result<CosmTxResponse, DaemonError> {
+        let timeout_height = Node::new_async(self.channel())._block_height().await? + 10u64;
+
+        let msgs = if self.has_authz() {
+            // We wrap authz messages
+            vec![Any {
+                type_url: "/cosmos.authz.v1beta1.MsgExec".to_string(),
+                value: MsgExec {
+                    grantee: self.account_id().to_string(),
+                    msgs,
+                }
+                .encode_to_vec(),
+            }]
+        } else {
+            msgs
+        };
+
+        let tx_body = TxBuilder::build_body(msgs, memo, timeout_height);
+
+        let tx_builder = TxBuilder::new(tx_body);
+
+        // We retry broadcasting the tx, with the following strategies
+        // 1. In case there is an `incorrect account sequence` error, we can retry as much as possible (doesn't cost anything to the user)
+        // 2. In case there is an insufficient_fee error, we retry once (costs fee to the user everytime we submit this kind of tx)
+        // 3. In case there is an other error, we fail
+
+        let tx_response = TxBroadcaster::default()
+            .add_strategy(insufficient_fee_strategy())
+            .add_strategy(account_sequence_strategy())
+            .broadcast(tx_builder, self)
+            .await?;
+
+        let resp = Node::new_async(self.channel())
+            ._find_tx(tx_response.txhash)
+            .await?;
+
+        assert_broadcast_code_cosm_response(resp)
+    }
+}

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -26,7 +26,7 @@ pub trait Signer: QuerySender<Error = DaemonError> + Sync {
 
     /// The account id of the signer.
     /// This is `_` prefixed because this conflict wih the TxSender trait
-    fn _account_id(&self) -> AccountId;
+    fn account_id(&self) -> AccountId;
 
     fn signing_account(
         &self,
@@ -78,7 +78,7 @@ pub trait Signer: QuerySender<Error = DaemonError> + Sync {
 
 impl<T: Signer + Sync> TxSender for T {
     fn account_id(&self) -> cosmrs::AccountId {
-        self._account_id()
+        self.account_id()
     }
 
     async fn commit_tx_any(

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -26,7 +26,6 @@ pub trait Signer: QuerySender<Error = DaemonError> + Sync {
     fn chain_id(&self) -> String;
 
     /// The account id of the signer.
-    /// This is `_` prefixed because this conflict wih the TxSender trait
     fn account_id(&self) -> AccountId;
 
     fn signing_account(

--- a/cw-orch-daemon/src/tx_broadcaster.rs
+++ b/cw-orch-daemon/src/tx_broadcaster.rs
@@ -1,7 +1,7 @@
 use cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse;
 use cw_orch_core::log::transaction_target;
 
-use crate::{queriers::Node, CosmTxResponse, DaemonError, TxBuilder, Wallet};
+use crate::{queriers::Node, senders::sign::CosmosSigner, CosmTxResponse, DaemonError, TxBuilder};
 
 pub type StrategyAction =
     fn(&mut TxBuilder, &Result<TxResponse, DaemonError>) -> Result<(), DaemonError>;
@@ -67,7 +67,7 @@ impl TxBroadcaster {
     pub async fn broadcast(
         mut self,
         mut tx_builder: TxBuilder,
-        wallet: &Wallet,
+        wallet: &impl CosmosSigner,
     ) -> Result<TxResponse, DaemonError> {
         let mut tx_retry = true;
 
@@ -122,7 +122,7 @@ fn strategy_condition_met(
 
 async fn broadcast_helper(
     tx_builder: &mut TxBuilder,
-    wallet: &Wallet,
+    wallet: &impl CosmosSigner,
 ) -> Result<TxResponse, DaemonError> {
     let tx = tx_builder.build(wallet).await?;
     let tx_response = wallet.broadcast_tx(tx).await?;

--- a/cw-orch-daemon/src/tx_broadcaster.rs
+++ b/cw-orch-daemon/src/tx_broadcaster.rs
@@ -63,17 +63,16 @@ impl TxBroadcaster {
         self
     }
 
-    // We can't make async recursions easily because wallet is not `Sync`
-    // Thus we use a `while` loop structure here
+    /// Broadcasts a transaction with the given signer
     pub async fn broadcast(
         mut self,
         mut tx_builder: TxBuilder,
-        wallet: &impl Signer,
+        signer: &impl Signer,
     ) -> Result<TxResponse, DaemonError> {
         let mut tx_retry = true;
 
         // We try and broadcast once
-        let mut tx_response = broadcast_helper(&mut tx_builder, wallet).await;
+        let mut tx_response = broadcast_helper(&mut tx_builder, signer).await;
         log::info!(
             target: &transaction_target(),
             "Awaiting TX inclusion in block..."
@@ -91,7 +90,7 @@ impl TxBroadcaster {
                     tx_retry = true;
 
                     // We still await for the next block, to avoid spamming retry when an error occurs
-                    let block_speed = Node::new_async(wallet.channel())
+                    let block_speed = Node::new_async(signer.channel())
                         ._average_block_speed(None)
                         .await?;
                     log::warn!(
@@ -102,7 +101,7 @@ impl TxBroadcaster {
                     );
                     tokio::time::sleep(block_speed).await;
 
-                    tx_response = broadcast_helper(&mut tx_builder, wallet).await;
+                    tx_response = broadcast_helper(&mut tx_builder, signer).await;
                     continue;
                 }
             }
@@ -123,10 +122,10 @@ fn strategy_condition_met(
 
 async fn broadcast_helper(
     tx_builder: &mut TxBuilder,
-    wallet: &impl Signer,
+    signer: &impl Signer,
 ) -> Result<TxResponse, DaemonError> {
-    let tx = tx_builder.build(wallet).await?;
-    let tx_response = wallet.broadcast_tx(tx).await?;
+    let tx = tx_builder.build(signer).await?;
+    let tx_response = signer.broadcast_tx(tx).await?;
     log::debug!(target: &transaction_target(), "TX broadcast response: {:?}", tx_response);
 
     assert_broadcast_code_response(tx_response)

--- a/cw-orch-daemon/src/tx_broadcaster.rs
+++ b/cw-orch-daemon/src/tx_broadcaster.rs
@@ -1,6 +1,7 @@
 use cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse;
 use cw_orch_core::log::transaction_target;
 
+use crate::senders::tx::TxSender;
 use crate::{queriers::Node, senders::sign::CosmosSigner, CosmTxResponse, DaemonError, TxBuilder};
 
 pub type StrategyAction =

--- a/cw-orch-daemon/src/tx_broadcaster.rs
+++ b/cw-orch-daemon/src/tx_broadcaster.rs
@@ -2,7 +2,7 @@ use cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse;
 use cw_orch_core::log::transaction_target;
 
 use crate::senders::tx::TxSender;
-use crate::{queriers::Node, senders::sign::CosmosSigner, CosmTxResponse, DaemonError, TxBuilder};
+use crate::{queriers::Node, senders::sign::Signer, CosmTxResponse, DaemonError, TxBuilder};
 
 pub type StrategyAction =
     fn(&mut TxBuilder, &Result<TxResponse, DaemonError>) -> Result<(), DaemonError>;
@@ -68,7 +68,7 @@ impl TxBroadcaster {
     pub async fn broadcast(
         mut self,
         mut tx_builder: TxBuilder,
-        wallet: &impl CosmosSigner,
+        wallet: &impl Signer,
     ) -> Result<TxResponse, DaemonError> {
         let mut tx_retry = true;
 
@@ -123,7 +123,7 @@ fn strategy_condition_met(
 
 async fn broadcast_helper(
     tx_builder: &mut TxBuilder,
-    wallet: &impl CosmosSigner,
+    wallet: &impl Signer,
 ) -> Result<TxResponse, DaemonError> {
     let tx = tx_builder.build(wallet).await?;
     let tx_response = wallet.broadcast_tx(tx).await?;

--- a/cw-orch-daemon/src/tx_builder.rs
+++ b/cw-orch-daemon/src/tx_builder.rs
@@ -10,7 +10,7 @@ use cosmwasm_std::Addr;
 use cw_orch_core::log::transaction_target;
 
 use crate::env::DaemonEnvVars;
-use crate::senders::sign::{CosmosSigner, SigningAccount};
+use crate::senders::sign::{Signer, SigningAccount};
 
 use super::DaemonError;
 
@@ -80,7 +80,7 @@ impl TxBuilder {
     }
 
     /// Simulates the transaction and returns the necessary gas fee returned by the simulation on a node
-    pub async fn simulate(&self, wallet: &impl CosmosSigner) -> Result<u64, DaemonError> {
+    pub async fn simulate(&self, wallet: &impl Signer) -> Result<u64, DaemonError> {
         // get the account number of the wallet
         let SigningAccount {
             account_number,
@@ -97,7 +97,7 @@ impl TxBuilder {
 
     /// Builds the raw tx with a given body and fee and signs it.
     /// Sets the TxBuilder's gas limit to its simulated amount for later use.
-    pub async fn build(&mut self, wallet: &impl CosmosSigner) -> Result<Raw, DaemonError> {
+    pub async fn build(&mut self, wallet: &impl Signer) -> Result<Raw, DaemonError> {
         // get the account number of the wallet
         let SigningAccount {
             account_number,

--- a/cw-orch-daemon/src/tx_builder.rs
+++ b/cw-orch-daemon/src/tx_builder.rs
@@ -1,19 +1,22 @@
 use std::str::FromStr;
 
-use cosmrs::tx::{ModeInfo, SignMode};
 use cosmrs::AccountId;
 use cosmrs::{
-    proto::cosmos::auth::v1beta1::BaseAccount,
     tendermint::chain::Id,
-    tx::{self, Body, Fee, Raw, SequenceNumber, SignDoc, SignerInfo},
+    tx::{self, Body, Fee, Raw, SequenceNumber, SignDoc},
     Any, Coin,
 };
 use cosmwasm_std::Addr;
 use cw_orch_core::log::transaction_target;
 
-use crate::Wallet;
+use crate::env::DaemonEnvVars;
+use crate::senders::sign::{CosmosSigner, SigningAccount};
 
 use super::DaemonError;
+
+const GAS_BUFFER: f64 = 1.3;
+const BUFFER_THRESHOLD: u64 = 200_000;
+const SMALL_GAS_BUFFER: f64 = 1.4;
 
 /// Struct used to build a raw transaction and broadcast it with a sender.
 #[derive(Clone, Debug)]
@@ -77,13 +80,12 @@ impl TxBuilder {
     }
 
     /// Simulates the transaction and returns the necessary gas fee returned by the simulation on a node
-    pub async fn simulate(&self, wallet: &Wallet) -> Result<u64, DaemonError> {
+    pub async fn simulate(&self, wallet: &impl CosmosSigner) -> Result<u64, DaemonError> {
         // get the account number of the wallet
-        let BaseAccount {
+        let SigningAccount {
             account_number,
             sequence,
-            ..
-        } = wallet.base_account().await?;
+        } = wallet.signing_account().await?;
 
         // overwrite sequence if set (can be used for concurrent txs)
         let sequence = self.sequence.unwrap_or(sequence);
@@ -95,13 +97,12 @@ impl TxBuilder {
 
     /// Builds the raw tx with a given body and fee and signs it.
     /// Sets the TxBuilder's gas limit to its simulated amount for later use.
-    pub async fn build(&mut self, wallet: &Wallet) -> Result<Raw, DaemonError> {
+    pub async fn build(&mut self, wallet: &impl CosmosSigner) -> Result<Raw, DaemonError> {
         // get the account number of the wallet
-        let BaseAccount {
+        let SigningAccount {
             account_number,
             sequence,
-            ..
-        } = wallet.base_account().await?;
+        } = wallet.signing_account().await?;
 
         // overwrite sequence if set (can be used for concurrent txs)
         let sequence = self.sequence.unwrap_or(sequence);
@@ -123,7 +124,8 @@ impl TxBuilder {
                 .await?;
             log::debug!(target: &transaction_target(), "Simulated gas needed {:?}", sim_gas_used);
 
-            let (gas_expected, fee_amount) = wallet.get_fee_from_gas(sim_gas_used)?;
+            let (gas_expected, fee_amount) =
+                TxBuilder::get_fee_from_gas(sim_gas_used, wallet.gas_price()?)?;
 
             log::debug!(target: &transaction_target(), "Calculated fee needed: {:?}", fee_amount);
             // set the gas limit of self for future txs
@@ -133,12 +135,7 @@ impl TxBuilder {
             (fee_amount, gas_expected)
         };
 
-        let fee = Self::build_fee(
-            tx_fee,
-            &wallet.get_fee_token(),
-            gas_limit,
-            wallet.options.fee_granter.clone(),
-        )?;
+        let fee = wallet.build_fee(tx_fee, gas_limit)?;
 
         log::debug!(
             target: &transaction_target(),
@@ -148,19 +145,33 @@ impl TxBuilder {
             sequence
         );
 
-        let auth_info = SignerInfo {
-            public_key: wallet.private_key.get_signer_public_key(&wallet.secp),
-            mode_info: ModeInfo::single(SignMode::Direct),
-            sequence,
-        }
-        .auth_info(fee);
+        let auth_info = wallet.signer_info(sequence).auth_info(fee);
 
         let sign_doc = SignDoc::new(
             &self.body,
             &auth_info,
-            &Id::try_from(wallet.chain_info.chain_id.to_string())?,
+            &Id::try_from(wallet.chain_id())?,
             account_number,
         )?;
         wallet.sign(sign_doc).map_err(Into::into)
+    }
+
+    /// Compute the gas fee from the expected gas in the transaction
+    /// Applies a Gas Buffer for including signature verification
+    pub(crate) fn get_fee_from_gas(gas: u64, gas_price: f64) -> Result<(u64, u128), DaemonError> {
+        let mut gas_expected = if let Some(gas_buffer) = DaemonEnvVars::gas_buffer() {
+            gas as f64 * gas_buffer
+        } else if gas < BUFFER_THRESHOLD {
+            gas as f64 * SMALL_GAS_BUFFER
+        } else {
+            gas as f64 * GAS_BUFFER
+        };
+
+        let min_gas = DaemonEnvVars::min_gas();
+        gas_expected = (min_gas as f64).max(gas_expected);
+
+        let fee_amount = gas_expected * (gas_price + 0.00001);
+
+        Ok((gas_expected as u64, fee_amount as u128))
     }
 }


### PR DESCRIPTION
This PR aims at making the TxBroadcaster available to other types of Signers that want to implement their own signing logic, very close to the CosmosSender signing logic. 

This implementation is done to accomodate for Xion Senders that have a different signing mechanism

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
