### PR TITLE
Changed version for LGPL

### DIFF
--- a/packages/cw-orch-core/Cargo.toml
+++ b/packages/cw-orch-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-core"
-version = "2.1.0"
+version = "2.1.1"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/cw-orch-mock/Cargo.toml
+++ b/packages/cw-orch-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-mock"
-version = "0.24.1"
+version = "0.24.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/packages/cw-orch-networks/Cargo.toml
+++ b/packages/cw-orch-networks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-networks"
-version = "0.24.1"
+version = "0.24.2"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/cw-orch-traits/Cargo.toml
+++ b/packages/cw-orch-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-traits"
-version = "0.24.0"
+version = "0.24.1"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/interchain/interchain-core/src/env.rs
+++ b/packages/interchain/interchain-core/src/env.rs
@@ -146,7 +146,7 @@ pub trait InterchainEnv<Chain: IbcQueryHandler>: Clone {
     /// use counter_contract::CounterContract;
     /// let interchain = MockBech32InterchainEnv::new(vec![("osmosis-1","osmo"),("archway-1","arch")]);
     ///
-    /// let all_chains: Vec<&MockBeck32> = interchain.chains().collect();
+    /// let all_chains: Vec<&MockBech32> = interchain.chains().collect();
     ///
     /// ```
     fn chains<'a>(&'a self) -> impl Iterator<Item = &'a Chain>

--- a/packages/interchain/interchain-daemon/src/interchain_env.rs
+++ b/packages/interchain/interchain-daemon/src/interchain_env.rs
@@ -308,7 +308,7 @@ impl<C: ChannelCreator> DaemonInterchain<C> {
     /// let src_chain = OSMOSIS_1;
     ///
     /// let interchain = DaemonInterchain::new(
-    ///     vec![(src_chain.clone(), None), (dst_chain, None)],
+    ///     vec![src_chain.clone(), dst_chain],
     ///     &ChannelCreationValidator,
     /// ).unwrap();
     ///

--- a/packages/macros/cw-orch-contract-derive/Cargo.toml
+++ b/packages/macros/cw-orch-contract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-contract-derive"
-version = "0.21.0"
+version = "0.21.1"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/macros/cw-orch-fns-derive/Cargo.toml
+++ b/packages/macros/cw-orch-fns-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-fns-derive"
-version = "0.23.0"
+version = "0.23.1"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
This PR aims at updating version for crates with the new LGPL license. 
cw-orch-daemon and cw-orch are not included here, because cw-orch-daemon 0.26.0 is already published. 
We are publishing via another un-merged branch (https://github.com/AbstractSDK/cw-orchestrator/tree/publish/cw-orch-daemon/0.25.2)

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
