### PR TITLE
removed abstract cw20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ cosmos-sdk-proto = { version = "0.24.0", default-features = false }
 cw-multi-test = { package = "abstract-cw-multi-test", version = "2.0.2", features = [
   "cosmwasm_1_2",
 ] }
-cw20 = { package = "abstract-cw20", version = "3.0.0" }
-cw20-base = { package = "abstract-cw20-base", version = "3.0.0" }
+cw20 = { version = "2.0.0" }
+cw20-base = { version = "2.0.0" }
 
 osmosis-test-tube = { version = "25.0.0" }
 neutron-test-tube = { version = "4.2.0" }

--- a/contracts-ws/Cargo.toml
+++ b/contracts-ws/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [workspace.dependencies]
 cosmwasm-std = "2.0.0"
-cw20 = { package = "abstract-cw20", version = "2.0.0" }
-cw20-base = { package = "abstract-cw20-base", version = "2.0.0" }
+cw20 = { version = "2.0.0" }
+cw20-base = { version = "2.0.0" }
 cw-storage-plus = { version = "2.0.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw-orch-mock/Cargo.toml
+++ b/packages/cw-orch-mock/Cargo.toml
@@ -20,7 +20,6 @@ log = { workspace = true }
 
 [dev-dependencies]
 speculoos = { workspace = true }
-# Should be able to replace with workspace cw20 when abstract-cw-plus fork updates to CosmWasm 2
 cw20 = { version = "2.0.0" }
 cw20-base = { version = "2.0.0" }
 


### PR DESCRIPTION
This PR aims at removing abstract cw-plus dependencies. The cw-orch cw-plus dependencies is now integrated inside the repo.

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
