### PR TITLE
Add on-chain cw-orch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "packages/macros/*",
   "packages/interchain/*",
   "packages/integrations/*",
+  "packages/cw-orch-on-chain",
 ]
 exclude = [
   "test_contracts/compatibility-test", # TODO: add new after cw-orch-core 2.0.0 as it's breaking, it shouldn't be compatible

--- a/contracts-ws/contracts/counter_cousin/Cargo.toml
+++ b/contracts-ws/contracts/counter_cousin/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "counter-cousin-contract"
+version = "0.11.0"
+description = "counter constract"
+keywords = ["cosmwasm", "blockchain"]
+edition = { workspace = true }
+exclude = [".env"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["export"]
+export = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = "2.0"
+cosmwasm-schema = "2.1"
+schemars = "0.8.21"
+thiserror = { version = "1.0.63" }
+serde = { workspace = true }
+serde_json = "1.0.125"
+cw-orch = { workspace = true, features = ["daemon"] }
+# Unused, only there to check for wasm compatibility
+cw-orch-interchain = { workspace = true, features = ["daemon"] }
+
+cw-orch-on-chain = { path = "../../../packages/cw-orch-on-chain" }
+
+[dev-dependencies]
+# Deps for deployment
+dotenv = { version = "0.15.0" }
+pretty_env_logger = { version = "0.5.0" }
+cw-orch = { workspace = true, features = ["daemon"] }
+anyhow = { workspace = true }

--- a/contracts-ws/contracts/counter_cousin/README.md
+++ b/contracts-ws/contracts/counter_cousin/README.md
@@ -1,0 +1,3 @@
+Refer to [https://orchestrator.abstract.money/](https://orchestrator.abstract.money/) for more details on how to use this crate
+
+Check out the [examples](./examples) and [tests](./tests) in this crate to understand how to use it by example.

--- a/contracts-ws/contracts/counter_cousin/src/contract.rs
+++ b/contracts-ws/contracts/counter_cousin/src/contract.rs
@@ -1,0 +1,59 @@
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+};
+use cw2::set_contract_version;
+
+use crate::{error::*, execute, msg::*, query, state::*};
+
+// version info for migration info
+pub const CONTRACT_NAME: &str = "crates.io:counter";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// ANCHOR: interface_entry
+// ANCHOR: entry_point_line
+#[cfg_attr(feature = "export", entry_point)]
+// ANCHOR_END: entry_point_line
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let state = State {
+        count: msg.count,
+        owner: info.sender.clone(),
+        cousin: None,
+    };
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    STATE.save(deps.storage, &state)?;
+
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("owner", info.sender)
+        .add_attribute("count", msg.count.to_string()))
+}
+
+#[cfg_attr(feature = "export", entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Increment {} => execute::increment(deps),
+        ExecuteMsg::Reset { count } => execute::reset(deps, info, count),
+        ExecuteMsg::SetCousin { cousin } => execute::set_cousin(deps, env, info, cousin),
+    }
+}
+
+#[cfg_attr(feature = "export", entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::GetCount {} => to_json_binary(&query::count(deps)?),
+        QueryMsg::GetCousinCount {} => to_json_binary(&query::cousin_count(deps, env)?),
+        QueryMsg::GetRawCousinCount {} => to_json_binary(&query::raw_cousin_count(deps)?),
+    }
+}
+
+// ANCHOR_END: interface_entry

--- a/contracts-ws/contracts/counter_cousin/src/error.rs
+++ b/contracts-ws/contracts/counter_cousin/src/error.rs
@@ -1,0 +1,13 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, PartialEq, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+    // Add any other custom errors you like here.
+    // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
+}

--- a/contracts-ws/contracts/counter_cousin/src/execute.rs
+++ b/contracts-ws/contracts/counter_cousin/src/execute.rs
@@ -1,0 +1,40 @@
+use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
+
+use crate::{error::*, state::*};
+
+pub fn increment(deps: DepsMut) -> Result<Response, ContractError> {
+    STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
+        state.count += 1;
+        Ok(state)
+    })?;
+
+    Ok(Response::new().add_attribute("action", "increment"))
+}
+
+pub fn reset(deps: DepsMut, info: MessageInfo, count: i32) -> Result<Response, ContractError> {
+    STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
+        if info.sender != state.owner {
+            return Err(ContractError::Unauthorized {});
+        }
+        state.count = count;
+        Ok(state)
+    })?;
+    Ok(Response::new().add_attribute("action", "reset"))
+}
+
+pub fn set_cousin(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    cousin: String,
+) -> Result<Response, ContractError> {
+    let cousin_addr = deps.api.addr_validate(&cousin)?;
+    let state = STATE.load(deps.storage)?;
+    if info.sender != state.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    crate::CounterContract::save(deps.branch(), &env, "cousin", cousin_addr.clone());
+
+    Ok(Response::new().add_attribute("action", "set_cousin"))
+}

--- a/contracts-ws/contracts/counter_cousin/src/interface.rs
+++ b/contracts-ws/contracts/counter_cousin/src/interface.rs
@@ -1,0 +1,103 @@
+// ANCHOR: custom_interface
+use cw_orch::{interface, prelude::*};
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cw_orch_on_chain::core::OnChain;
+
+use cosmwasm_std::{Deps, Env};
+use std::collections::HashMap;
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
+pub struct CounterContract;
+
+impl<Chain: CwEnv> Uploadable for CounterContract<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(_chain: &ChainInfoOwned) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("counter_contract")
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper() -> Box<dyn MockContract<Empty>> {
+        Box::new(ContractWrapper::new_with_empty(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+}
+// ANCHOR_END: custom_interface
+
+use crate::contract::CONTRACT_NAME;
+use cosmwasm_std::DepsMut;
+use cw_orch::anyhow::Result;
+use cw_orch::prelude::queriers::Node;
+use cw_orch_on_chain::core::OnChainDeps;
+
+impl<'a> CounterContract<OnChain<'a>> {
+    pub fn load(
+        deps: impl Into<OnChainDeps<'a>>,
+        env: &Env,
+        contract_id: &str,
+    ) -> CounterContract<OnChain<'a>> {
+        let chain = OnChain::new(deps, env);
+        CounterContract::new(contract_id, chain)
+    }
+
+    pub fn save(
+        deps: DepsMut<'a>,
+        env: &Env,
+        contract_id: &str,
+        address: Addr,
+    ) -> CounterContract<OnChain<'a>> {
+        let chain = OnChain::new(deps, env);
+        let contract = CounterContract::new(contract_id, chain);
+        contract.set_address(&address);
+        contract
+    }
+
+    pub fn with_address(
+        deps: Deps<'a>,
+        env: &Env,
+        contract_id: &str,
+        address: Addr,
+    ) -> CounterContract<OnChain<'a>> {
+        let chain = OnChain::new(deps, env);
+        let contract = CounterContract::new(contract_id, chain);
+        contract.set_address(&address);
+        contract
+    }
+}
+
+// ANCHOR: daemon
+impl CounterContract<Daemon> {
+    /// Deploys the counter contract at a specific block height
+    pub fn await_launch(&self) -> Result<()> {
+        let daemon = self.environment();
+        let rt = daemon.rt_handle.clone();
+
+        rt.block_on(async {
+            // Get the node query client, there are a lot of other clients available.
+            let node: Node = daemon.querier();
+            let mut latest_block = node.latest_block().unwrap();
+
+            while latest_block.height < 100 {
+                // wait for the next block
+                daemon.next_block().unwrap();
+                latest_block = node.latest_block().unwrap();
+            }
+        });
+
+        let contract = CounterContract::new(CONTRACT_NAME, daemon.clone());
+
+        // Upload the contract
+        contract.upload().unwrap();
+
+        // Instantiate the contract
+        let msg = InstantiateMsg { count: 1i32 };
+        contract.instantiate(&msg, None, &[]).unwrap();
+
+        Ok(())
+    }
+}
+// ANCHOR_END: daemon

--- a/contracts-ws/contracts/counter_cousin/src/lib.rs
+++ b/contracts-ws/contracts/counter_cousin/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod contract;
+mod error;
+pub(crate) mod execute;
+pub mod interface;
+pub mod msg;
+pub(crate) mod query;
+pub mod state;
+
+pub use error::ContractError;
+pub use interface::CounterContract;
+pub use msg::{ExecuteMsgFns as CounterExecuteMsgFns, QueryMsgFns as CounterQueryMsgFns};

--- a/contracts-ws/contracts/counter_cousin/src/msg.rs
+++ b/contracts-ws/contracts/counter_cousin/src/msg.rs
@@ -1,0 +1,62 @@
+#![warn(missing_docs)]
+//! # Counter contract
+
+use cosmwasm_schema::{cw_serde, QueryResponses};
+
+#[cw_serde]
+/// Instantiate method for counter
+pub struct InstantiateMsg {
+    /// Initial count
+    pub count: i32,
+}
+
+// ANCHOR: exec_msg
+#[cw_serde]
+#[derive(cw_orch::ExecuteFns)] // Function generation
+/// Execute methods for counter
+pub enum ExecuteMsg {
+    /// Increment count by one
+    Increment {},
+    /// Reset count
+    Reset {
+        /// Count value after reset
+        count: i32,
+    },
+    SetCousin {
+        cousin: String,
+    },
+}
+// ANCHOR_END: exec_msg
+
+// ANCHOR: query_msg
+#[cw_serde]
+#[derive(cw_orch::QueryFns)] // Function generation
+#[derive(QueryResponses)]
+/// Query methods for counter
+pub enum QueryMsg {
+    /// GetCount returns the current count as a json-encoded number
+    #[returns(GetCountResponse)]
+    GetCount {},
+    /// GetCount returns the current count as a json-encoded number
+    #[returns(GetCountResponse)]
+    GetCousinCount {},
+    /// GetCount returns the current count as a json-encoded number
+    #[returns(GetCountResponse)]
+    GetRawCousinCount {},
+}
+
+// Custom response for the query
+#[cw_serde]
+/// Response from get_count query
+pub struct GetCountResponse {
+    /// Current count in the state
+    pub count: i32,
+}
+// ANCHOR_END: query_msg
+
+#[cw_serde]
+/// Migrate message for count contract
+pub struct MigrateMsg {
+    /// Your favorite type of tea
+    pub t: String,
+}

--- a/contracts-ws/contracts/counter_cousin/src/query.rs
+++ b/contracts-ws/contracts/counter_cousin/src/query.rs
@@ -1,0 +1,27 @@
+use cosmwasm_std::{to_json_binary, Deps, Env, QueryRequest, StdResult, WasmQuery};
+
+use crate::interface::CounterContract;
+use crate::msg::QueryMsgFns;
+use crate::{
+    msg::{GetCountResponse, QueryMsg},
+    state::STATE,
+};
+
+pub fn count(deps: Deps) -> StdResult<GetCountResponse> {
+    let state = STATE.load(deps.storage)?;
+    Ok(GetCountResponse { count: state.count })
+}
+
+pub fn cousin_count(deps: Deps, env: Env) -> StdResult<GetCountResponse> {
+    CounterContract::load(deps, &env, "cousin")
+        .get_count()
+        .map_err(Into::into)
+}
+
+pub fn raw_cousin_count(deps: Deps) -> StdResult<GetCountResponse> {
+    let state = STATE.load(deps.storage)?;
+    let cousin_state = STATE.query(&deps.querier, state.cousin.unwrap())?;
+    Ok(GetCountResponse {
+        count: cousin_state.count,
+    })
+}

--- a/contracts-ws/contracts/counter_cousin/src/state.rs
+++ b/contracts-ws/contracts/counter_cousin/src/state.rs
@@ -1,0 +1,14 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct State {
+    pub count: i32,
+    pub owner: Addr,
+    pub cousin: Option<Addr>,
+}
+
+pub const STATE: Item<State> = Item::new("state");

--- a/contracts-ws/contracts/counter_cousin/tests/integration_tests.rs
+++ b/contracts-ws/contracts/counter_cousin/tests/integration_tests.rs
@@ -1,0 +1,79 @@
+// ANCHOR: all
+use counter_cousin_contract::{
+    msg::{GetCountResponse, InstantiateMsg, QueryMsg},
+    ContractError, CounterContract, CounterExecuteMsgFns, CounterQueryMsgFns,
+};
+// Use prelude to get all the necessary imports
+use cw_orch::prelude::*;
+
+use cosmwasm_std::Addr;
+
+// consts for testing
+const USER: &str = "user";
+const ADMIN: &str = "admin";
+// ANCHOR: integration_test
+
+// ANCHOR: count_test
+#[test]
+fn count() -> anyhow::Result<()> {
+    // Create the mock. This will be our chain object throughout
+    let mock = Mock::new(ADMIN);
+    let user = Addr::unchecked(USER);
+
+    // Set up the contract (Definition below) ↓↓
+    let (contract, cousin) = setup(mock.clone())?;
+
+    // Increment the count of the contract
+    contract.call_as(&user).increment()?;
+    contract.call_as(&user).increment()?;
+
+    cousin.call_as(&user).increment()?;
+    cousin.call_as(&user).increment()?;
+    cousin.call_as(&user).increment()?;
+
+    let count = contract.get_count()?;
+    assert_eq!(count.count, 3);
+
+    let count = contract.get_cousin_count()?;
+    assert_eq!(count.count, 4);
+
+    let count = cousin.get_count()?;
+    assert_eq!(count.count, 4);
+
+    let count = cousin.get_cousin_count()?;
+    assert_eq!(count.count, 3);
+
+    Ok(())
+}
+// ANCHOR_END: count_test
+
+// ANCHOR: setup
+/// Instantiate the contract in any CosmWasm environment
+fn setup<Chain: CwEnv>(
+    chain: Chain,
+) -> anyhow::Result<(CounterContract<Chain>, CounterContract<Chain>)> {
+    // ANCHOR: constructor
+    // Construct the counter interface
+    let contract = CounterContract::new("cousin", chain.clone());
+    let cousin = CounterContract::new("counter", chain.clone());
+    // ANCHOR_END: constructor
+
+    // Upload the contract
+    contract.upload()?;
+    cousin.upload()?;
+
+    // Instantiate the contract
+    let msg = InstantiateMsg { count: 1i32 };
+    contract.instantiate(&msg, None, &[])?;
+    cousin.instantiate(&msg, None, &[])?;
+
+    contract.set_cousin(cousin.address()?)?;
+    cousin.set_cousin(contract.address()?)?;
+
+    // Return the interface
+    Ok((contract, cousin))
+}
+// ANCHOR_END: setup
+
+// ANCHOR_END: integration_test
+// ANCHOR_END: all

--- a/packages/cw-orch-core/src/environment/state.rs
+++ b/packages/cw-orch-core/src/environment/state.rs
@@ -16,7 +16,7 @@ pub trait ChainState {
 /// This Interface allows for managing the local state of a deployment on any CosmWasm-supported environment.
 pub trait StateInterface: Clone {
     /// Get the address of a contract using the specified contract id.
-    fn get_address<'b>(&'b self, contract_id: &str) -> Result<Addr, CwEnvError>;
+    fn get_address(&self, contract_id: &str) -> Result<Addr, CwEnvError>;
 
     /// Set the address of a contract using the specified contract id.
     fn set_address(&mut self, contract_id: &str, address: &Addr);

--- a/packages/cw-orch-core/src/environment/state.rs
+++ b/packages/cw-orch-core/src/environment/state.rs
@@ -16,7 +16,7 @@ pub trait ChainState {
 /// This Interface allows for managing the local state of a deployment on any CosmWasm-supported environment.
 pub trait StateInterface: Clone {
     /// Get the address of a contract using the specified contract id.
-    fn get_address(&self, contract_id: &str) -> Result<Addr, CwEnvError>;
+    fn get_address<'b>(&'b self, contract_id: &str) -> Result<Addr, CwEnvError>;
 
     /// Set the address of a contract using the specified contract id.
     fn set_address(&mut self, contract_id: &str, address: &Addr);

--- a/packages/cw-orch-core/src/error.rs
+++ b/packages/cw-orch-core/src/error.rs
@@ -6,7 +6,7 @@ use std::{
     str::ParseBoolError,
 };
 
-use cosmwasm_std::Instantiate2AddressError;
+use cosmwasm_std::{Instantiate2AddressError, StdError};
 use thiserror::Error;
 
 /// cw-orchestrator error wrapper using thiserror.
@@ -62,5 +62,11 @@ impl CwEnvError {
             CwEnvError::AnyError(e) => e.downcast(),
             _ => panic!("Unexpected error type"),
         }
+    }
+}
+
+impl From<CwEnvError> for StdError {
+    fn from(val: CwEnvError) -> Self {
+        StdError::generic_err(val.to_string())
     }
 }

--- a/packages/cw-orch-on-chain/Cargo.toml
+++ b/packages/cw-orch-on-chain/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cw-orch-on-chain"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cw-orch-core = { workspace = true }
+cosmwasm-std = { workspace = true }
+serde.workspace = true
+thiserror.workspace = true
+cw-storage-plus.workspace = true

--- a/packages/cw-orch-on-chain/src/core.rs
+++ b/packages/cw-orch-on-chain/src/core.rs
@@ -1,0 +1,442 @@
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    collections::HashMap,
+    rc::Rc,
+    sync::Arc,
+};
+
+use cosmwasm_std::{
+    instantiate2_address, to_json_binary, Addr, Api, Binary, Coin, CosmosMsg, Deps, DepsMut, Env,
+    QuerierWrapper, StdError, Storage,
+};
+use cw_orch_core::{
+    environment::{
+        BankQuerier, ChainState, DefaultQueriers, EnvironmentQuerier, IndexResponse, NodeQuerier,
+        Querier, QuerierGetter, QueryHandler, StateInterface, TxHandler, WasmQuerier,
+    },
+    CwEnvError,
+};
+use cw_storage_plus::Item;
+use serde::Serialize;
+
+use crate::error::OnChainError;
+
+#[derive(Clone)]
+pub enum OnChainDeps<'a> {
+    Mut(Rc<RefCell<DepsMut<'a>>>),
+    Ref(Rc<RefCell<Deps<'a>>>),
+}
+
+impl<'a> From<DepsMut<'a>> for OnChainDeps<'a> {
+    fn from(value: DepsMut<'a>) -> Self {
+        OnChainDeps::Mut(Rc::new(RefCell::new(value)))
+    }
+}
+impl<'a> From<Deps<'a>> for OnChainDeps<'a> {
+    fn from(value: Deps<'a>) -> Self {
+        OnChainDeps::Ref(Rc::new(RefCell::new(value)))
+    }
+}
+
+impl<'a> OnChainDeps<'a> {
+    pub fn storage(&self) -> Ref<'_, dyn Storage> {
+        match self {
+            OnChainDeps::Mut(deps) => Ref::map(deps.borrow(), |deps| deps.storage),
+            OnChainDeps::Ref(deps) => Ref::map(deps.borrow(), |deps| deps.storage),
+        }
+    }
+
+    pub fn storage_mut(&self) -> Result<RefMut<'_, dyn Storage>, StdError> {
+        match self {
+            OnChainDeps::Mut(deps) => Ok(RefMut::map(deps.borrow_mut(), |deps| deps.storage)),
+            OnChainDeps::Ref(_deps) => Err(StdError::generic_err(
+                "Can't access storage mut on ref deps",
+            )),
+        }
+    }
+
+    pub fn querier(&self) -> Ref<'_, QuerierWrapper<'a>> {
+        match self {
+            OnChainDeps::Mut(deps) => Ref::map(deps.borrow(), |deps| &deps.querier),
+            OnChainDeps::Ref(deps) => Ref::map(deps.borrow(), |deps| &deps.querier),
+        }
+    }
+
+    pub fn api(&self) -> Ref<'_, dyn Api> {
+        match self {
+            OnChainDeps::Mut(deps) => Ref::map(deps.borrow(), |deps| deps.api),
+            OnChainDeps::Ref(deps) => Ref::map(deps.borrow(), |deps| deps.api),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct OnChain<'a> {
+    pub env: Env,
+    pub deps: OnChainDeps<'a>,
+    pub state: Rc<RefCell<HashMap<String, Addr>>>,
+}
+
+impl<'a> OnChain<'a> {
+    pub fn new(deps: impl Into<OnChainDeps<'a>>, env: &Env) -> OnChain<'a> {
+        OnChain {
+            env: env.clone(),
+            deps: deps.into(),
+            state: Rc::new(RefCell::new(HashMap::default())),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CwOrchCosmosMsg(pub CosmosMsg);
+
+impl From<CosmosMsg> for CwOrchCosmosMsg {
+    fn from(value: CosmosMsg) -> Self {
+        Self(value)
+    }
+}
+
+impl IndexResponse for CwOrchCosmosMsg {
+    fn events(&self) -> Vec<cosmwasm_std::Event> {
+        unimplemented!()
+    }
+
+    fn event_attr_value(
+        &self,
+        _event_type: &str,
+        _attr_key: &str,
+    ) -> cosmwasm_std::StdResult<String> {
+        unimplemented!()
+    }
+
+    fn event_attr_values(&self, _event_type: &str, _attr_key: &str) -> Vec<String> {
+        unimplemented!()
+    }
+
+    fn data(&self) -> Option<cosmwasm_std::Binary> {
+        unimplemented!()
+    }
+}
+
+#[derive(Clone)]
+pub struct OnChainState<'a> {
+    pub deps: OnChainDeps<'a>,
+    pub state: Rc<RefCell<HashMap<String, Addr>>>,
+}
+
+impl<'a> StateInterface for OnChainState<'a> {
+    fn get_address(&self, contract_id: &str) -> Result<Addr, cw_orch_core::CwEnvError> {
+        let complete_contract_id = format!("cw-orch-on-chain-{}", contract_id);
+        let store = Item::<Addr>::new_dyn(complete_contract_id.to_string());
+
+        self.state
+            .borrow()
+            .get(&complete_contract_id)
+            .cloned()
+            .ok_or(StdError::not_found(complete_contract_id))
+            .or_else(|_| store.load(&*self.deps.storage()))
+            .map_err(Into::into)
+    }
+
+    fn set_address(&mut self, contract_id: &str, address: &Addr) {
+        let complete_contract_id = format!("cw-orch-on-chain-{}", contract_id);
+        let store = Item::<Addr>::new_dyn(complete_contract_id.to_string());
+
+        match self.deps.storage_mut() {
+            Ok(mut storage_mut) => {
+                store.save(&mut *(storage_mut), address).unwrap();
+            }
+            Err(_) => {
+                self.state
+                    .borrow_mut()
+                    .insert(complete_contract_id, address.clone());
+            }
+        }
+    }
+
+    fn remove_address(&mut self, _contract_id: &str) {
+        todo!()
+    }
+
+    fn get_code_id(&self, contract_id: &str) -> Result<u64, cw_orch_core::CwEnvError> {
+        todo!()
+    }
+
+    fn set_code_id(&mut self, contract_id: &str, code_id: u64) {
+        todo!()
+    }
+
+    fn remove_code_id(&mut self, _contract_id: &str) {
+        todo!()
+    }
+
+    fn get_all_addresses(
+        &self,
+    ) -> Result<std::collections::HashMap<String, Addr>, cw_orch_core::CwEnvError> {
+        todo!()
+    }
+
+    fn get_all_code_ids(
+        &self,
+    ) -> Result<std::collections::HashMap<String, u64>, cw_orch_core::CwEnvError> {
+        todo!()
+    }
+}
+
+impl<'a> ChainState for OnChain<'a> {
+    type Out = OnChainState<'a>;
+
+    fn state(&self) -> Self::Out {
+        OnChainState {
+            deps: self.deps.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl<'a> TxHandler for OnChain<'a> {
+    type Response = CwOrchCosmosMsg;
+
+    type Error = OnChainError;
+
+    type ContractSource = ();
+
+    type Sender = Addr;
+
+    fn sender(&self) -> &Self::Sender {
+        &self.env.contract.address
+    }
+
+    fn sender_addr(&self) -> Addr {
+        self.env.contract.address.clone()
+    }
+
+    fn set_sender(&mut self, _sender: Self::Sender) {
+        unimplemented!()
+    }
+
+    fn upload<T: cw_orch_core::contract::interface_traits::Uploadable>(
+        &self,
+        _contract_source: &T,
+    ) -> Result<Self::Response, Self::Error> {
+        unimplemented!("Upload not possible from on-chain")
+    }
+
+    fn instantiate<I: Serialize + std::fmt::Debug>(
+        &self,
+        code_id: u64,
+        init_msg: &I,
+        label: Option<&str>,
+        admin: Option<&Addr>,
+        coins: &[cosmwasm_std::Coin],
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Instantiate {
+            admin: admin.map(|a| a.to_string()),
+            code_id,
+            msg: to_json_binary(init_msg)?,
+            funds: coins.to_vec(),
+            label: label.unwrap_or("Instantiated with cw-orch").to_string(),
+        })
+        .into())
+    }
+
+    fn instantiate2<I: Serialize + std::fmt::Debug>(
+        &self,
+        code_id: u64,
+        init_msg: &I,
+        label: Option<&str>,
+        admin: Option<&Addr>,
+        coins: &[cosmwasm_std::Coin],
+        salt: Binary,
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Instantiate2 {
+            admin: admin.map(|a| a.to_string()),
+            code_id,
+            msg: to_json_binary(init_msg)?,
+            funds: coins.to_vec(),
+            label: label.unwrap_or("Instantiated with cw-orch").to_string(),
+            salt,
+        })
+        .into())
+    }
+
+    fn execute<E: Serialize + std::fmt::Debug>(
+        &self,
+        exec_msg: &E,
+        coins: &[Coin],
+        contract_address: &Addr,
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Execute {
+            contract_addr: contract_address.to_string(),
+            msg: to_json_binary(exec_msg)?,
+            funds: coins.to_vec(),
+        })
+        .into())
+    }
+
+    fn migrate<M: Serialize + std::fmt::Debug>(
+        &self,
+        migrate_msg: &M,
+        new_code_id: u64,
+        contract_address: &Addr,
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Migrate {
+            contract_addr: contract_address.to_string(),
+            msg: to_json_binary(migrate_msg)?,
+            new_code_id,
+        })
+        .into())
+    }
+}
+
+impl<'a> QueryHandler for OnChain<'a> {
+    type Error = OnChainError;
+
+    fn wait_blocks(&self, _amount: u64) -> Result<(), Self::Error> {
+        unimplemented!("You can't manipulate blocks, you're on-chain")
+    }
+
+    fn wait_seconds(&self, _secs: u64) -> Result<(), Self::Error> {
+        unimplemented!("You can't manipulate time, you're on-chain")
+    }
+
+    fn next_block(&self) -> Result<(), Self::Error> {
+        unimplemented!("You can't manipulate blocks, you're on-chain")
+    }
+}
+
+impl<'a> Querier for OnChain<'a> {
+    type Error = OnChainError;
+}
+
+impl<'a> QuerierGetter<OnChain<'a>> for OnChain<'a> {
+    fn querier(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<'a> DefaultQueriers for OnChain<'a> {
+    type Bank = OnChain<'a>;
+
+    type Wasm = OnChain<'a>;
+
+    type Node = OnChain<'a>;
+}
+
+impl<'a> BankQuerier for OnChain<'a> {
+    fn balance(&self, address: &Addr, denom: Option<String>) -> Result<Vec<Coin>, Self::Error> {
+        todo!()
+    }
+
+    fn total_supply(&self) -> Result<Vec<Coin>, Self::Error> {
+        todo!()
+    }
+
+    fn supply_of(&self, denom: impl Into<String>) -> Result<Coin, Self::Error> {
+        todo!()
+    }
+}
+
+impl<'a> WasmQuerier for OnChain<'a> {
+    type Chain = OnChain<'a>;
+
+    fn code_id_hash(&self, code_id: u64) -> Result<cosmwasm_std::Checksum, Self::Error> {
+        Ok(self.code(code_id)?.checksum)
+    }
+
+    fn contract_info(
+        &self,
+        address: &Addr,
+    ) -> Result<cosmwasm_std::ContractInfoResponse, Self::Error> {
+        self.deps
+            .querier()
+            .query_wasm_contract_info(address)
+            .map_err(Into::into)
+    }
+
+    fn raw_query(&self, address: &Addr, query_keys: Vec<u8>) -> Result<Vec<u8>, Self::Error> {
+        self.deps
+            .querier()
+            .query_wasm_raw(address, query_keys)
+            .map(|r| r.unwrap_or_default())
+            .map_err(Into::into)
+    }
+
+    fn smart_query<Q: Serialize, T: serde::de::DeserializeOwned>(
+        &self,
+        address: &Addr,
+        query_msg: &Q,
+    ) -> Result<T, Self::Error> {
+        self.deps
+            .querier()
+            .query_wasm_smart(address, query_msg)
+            .map_err(Into::into)
+    }
+
+    fn code(&self, code_id: u64) -> Result<cosmwasm_std::CodeInfoResponse, Self::Error> {
+        self.deps
+            .querier()
+            .query_wasm_code_info(code_id)
+            .map_err(Into::into)
+    }
+
+    fn local_hash<
+        T: cw_orch_core::contract::interface_traits::Uploadable
+            + cw_orch_core::contract::interface_traits::ContractInstance<Self::Chain>,
+    >(
+        &self,
+        contract: &T,
+    ) -> Result<cosmwasm_std::Checksum, cw_orch_core::CwEnvError> {
+        unimplemented!()
+    }
+
+    fn instantiate2_addr(
+        &self,
+        code_id: u64,
+        creator: &Addr,
+        salt: cosmwasm_std::Binary,
+    ) -> Result<String, Self::Error> {
+        let checksum = self.code_id_hash(code_id)?;
+        let creator_canon = self.deps.api().addr_canonicalize(creator.as_str())?;
+        let canon = instantiate2_address(checksum.as_slice(), &creator_canon, salt.as_slice())?;
+        self.deps
+            .api()
+            .addr_humanize(&canon)
+            .map(|a| a.to_string())
+            .map_err(Into::into)
+    }
+}
+
+impl<'a> EnvironmentQuerier for OnChain<'a> {
+    fn env_info(&self) -> cw_orch_core::environment::EnvironmentInfo {
+        todo!()
+    }
+}
+
+impl<'a> NodeQuerier for OnChain<'a> {
+    type Response = CwOrchCosmosMsg;
+
+    fn latest_block(&self) -> Result<cosmwasm_std::BlockInfo, Self::Error> {
+        todo!()
+    }
+
+    fn block_by_height(&self, height: u64) -> Result<cosmwasm_std::BlockInfo, Self::Error> {
+        todo!()
+    }
+
+    fn block_height(&self) -> Result<u64, Self::Error> {
+        todo!()
+    }
+
+    fn block_time(&self) -> Result<u128, Self::Error> {
+        todo!()
+    }
+
+    fn simulate_tx(&self, tx_bytes: Vec<u8>) -> Result<u64, Self::Error> {
+        todo!()
+    }
+
+    fn find_tx(&self, hash: String) -> Result<Self::Response, Self::Error> {
+        todo!()
+    }
+}

--- a/packages/cw-orch-on-chain/src/core.rs
+++ b/packages/cw-orch-on-chain/src/core.rs
@@ -2,19 +2,15 @@ use std::{
     cell::{Ref, RefCell, RefMut},
     collections::HashMap,
     rc::Rc,
-    sync::Arc,
 };
 
 use cosmwasm_std::{
     instantiate2_address, to_json_binary, Addr, Api, Binary, Coin, CosmosMsg, Deps, DepsMut, Env,
     QuerierWrapper, StdError, Storage,
 };
-use cw_orch_core::{
-    environment::{
-        BankQuerier, ChainState, DefaultQueriers, EnvironmentQuerier, IndexResponse, NodeQuerier,
-        Querier, QuerierGetter, QueryHandler, StateInterface, TxHandler, WasmQuerier,
-    },
-    CwEnvError,
+use cw_orch_core::environment::{
+    BankQuerier, ChainState, DefaultQueriers, EnvironmentQuerier, IndexResponse, NodeQuerier,
+    Querier, QuerierGetter, QueryHandler, StateInterface, TxHandler, WasmQuerier,
 };
 use cw_storage_plus::Item;
 use serde::Serialize;
@@ -158,11 +154,11 @@ impl<'a> StateInterface for OnChainState<'a> {
         todo!()
     }
 
-    fn get_code_id(&self, contract_id: &str) -> Result<u64, cw_orch_core::CwEnvError> {
+    fn get_code_id(&self, _contract_id: &str) -> Result<u64, cw_orch_core::CwEnvError> {
         todo!()
     }
 
-    fn set_code_id(&mut self, contract_id: &str, code_id: u64) {
+    fn set_code_id(&mut self, _contract_id: &str, _code_id: u64) {
         todo!()
     }
 
@@ -324,7 +320,7 @@ impl<'a> DefaultQueriers for OnChain<'a> {
 }
 
 impl<'a> BankQuerier for OnChain<'a> {
-    fn balance(&self, address: &Addr, denom: Option<String>) -> Result<Vec<Coin>, Self::Error> {
+    fn balance(&self, _address: &Addr, _denom: Option<String>) -> Result<Vec<Coin>, Self::Error> {
         todo!()
     }
 
@@ -332,7 +328,7 @@ impl<'a> BankQuerier for OnChain<'a> {
         todo!()
     }
 
-    fn supply_of(&self, denom: impl Into<String>) -> Result<Coin, Self::Error> {
+    fn supply_of(&self, _denom: impl Into<String>) -> Result<Coin, Self::Error> {
         todo!()
     }
 }
@@ -385,7 +381,7 @@ impl<'a> WasmQuerier for OnChain<'a> {
             + cw_orch_core::contract::interface_traits::ContractInstance<Self::Chain>,
     >(
         &self,
-        contract: &T,
+        _contract: &T,
     ) -> Result<cosmwasm_std::Checksum, cw_orch_core::CwEnvError> {
         unimplemented!()
     }
@@ -420,7 +416,7 @@ impl<'a> NodeQuerier for OnChain<'a> {
         todo!()
     }
 
-    fn block_by_height(&self, height: u64) -> Result<cosmwasm_std::BlockInfo, Self::Error> {
+    fn block_by_height(&self, _height: u64) -> Result<cosmwasm_std::BlockInfo, Self::Error> {
         todo!()
     }
 
@@ -432,11 +428,11 @@ impl<'a> NodeQuerier for OnChain<'a> {
         todo!()
     }
 
-    fn simulate_tx(&self, tx_bytes: Vec<u8>) -> Result<u64, Self::Error> {
+    fn simulate_tx(&self, _tx_bytes: Vec<u8>) -> Result<u64, Self::Error> {
         todo!()
     }
 
-    fn find_tx(&self, hash: String) -> Result<Self::Response, Self::Error> {
+    fn find_tx(&self, _hash: String) -> Result<Self::Response, Self::Error> {
         todo!()
     }
 }

--- a/packages/cw-orch-on-chain/src/error.rs
+++ b/packages/cw-orch-on-chain/src/error.rs
@@ -1,0 +1,26 @@
+#![allow(missing_docs)]
+
+use cosmwasm_std::StdError;
+use cw_orch_core::CwEnvError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OnChainError {
+    #[error(transparent)]
+    CosmwasmStd(#[from] cosmwasm_std::StdError),
+
+    #[error(transparent)]
+    Instantiate2(#[from] cosmwasm_std::Instantiate2AddressError),
+}
+
+impl From<OnChainError> for CwEnvError {
+    fn from(val: OnChainError) -> Self {
+        CwEnvError::AnyError(val.into())
+    }
+}
+
+impl From<OnChainError> for StdError {
+    fn from(val: OnChainError) -> Self {
+        StdError::generic_err(val.to_string())
+    }
+}

--- a/packages/cw-orch-on-chain/src/lib.rs
+++ b/packages/cw-orch-on-chain/src/lib.rs
@@ -1,0 +1,17 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}
+
+pub mod core;
+pub mod error;


### PR DESCRIPTION
This Pr aims at allowing users to interact with contract with the following syntax: 

```rust
let query_result = Contract::load(deps, env).smart_query()?;
let execute_msg = Contract::load(deps, env).execute_msg()?;
```

This uses the existing CwEnv structure and the derived Execute and QueryMsgs to work


### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
