### PR TITLE
Add Cosmos Hub testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update syn to 2.0
 - Added cw-plus orchestrator interface to the repo. Pacing the way for more integrations inside this repository in the future
 - Add easier way to get PublicKey for `cw_orch_daemon::Wallet`
+- Added Cosmos hub Testnet
   
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Cw-orchestrator supports the following chains natively:
 🟥 LocalNet, 🟦 Testnet, 🟩 Mainnet
 
 - Archway 🟦🟩
+- Cosmos 🟩
 - Injective 🟦🟩
 - Juno 🟥🟦🟩
 - Kujira 🟦

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Cw-orchestrator supports the following chains natively:
 🟥 LocalNet, 🟦 Testnet, 🟩 Mainnet
 
 - Archway 🟦🟩
-- Cosmos 🟩
+- Cosmos Hub 🟩
 - Injective 🟦🟩
 - Juno 🟥🟦🟩
 - Kujira 🟦

--- a/docs/src/chains/cosmos.md
+++ b/docs/src/chains/cosmos.md
@@ -10,7 +10,7 @@ The Cosmos Hub is the first of thousands of interconnected blockchains that will
 
 ## Usage
 
-See how to setup your main function in the [main function](../contracts/scripting.md#main-function) section. Update the network passed into the `Daemon` builder to be `networks::COSMOS_TESTNET`.
+See how to setup your main function in the [main function](../contracts/scripting.md#main-function) section. Update the network passed into the `Daemon` builder to be `networks::COSMOS_HUB_TESTNET`.
 ## References
 
 - [Cosmos Hub Documentation](https://hub.cosmos.network/main)

--- a/docs/src/chains/cosmos.md
+++ b/docs/src/chains/cosmos.md
@@ -1,0 +1,17 @@
+# Cosmos Hub
+
+The Cosmos Hub is the first of thousands of interconnected blockchains that will eventually comprise the Cosmos Network. The primary token of the Cosmos Hub is the ATOM, but the Hub will support many tokens in the future.
+
+[Cosmos Hub Website](https://cosmos.network/)
+
+```rust,ignore
+{{#include ../../../packages/cw-orch-networks/src/networks/cosmos.rs:cosmos}}
+```
+
+## Usage
+
+See how to setup your main function in the [main function](../contracts/scripting.md#main-function) section. Update the network passed into the `Daemon` builder to be `networks::COSMOS_TESTNET`.
+## References
+
+- [Cosmos Hub Documentation](https://hub.cosmos.network/main)
+- [Cosmos Hub Discord](https://discord.gg/interchain)

--- a/docs/src/chains/index.md
+++ b/docs/src/chains/index.md
@@ -3,7 +3,7 @@
 cw-orchestrator currently explicitly supports the chains in this section:
 
 - [Archway](./archway.md)
-- [Cosmos](./cosmos.md)
+- [Cosmos Hub](./cosmos.md)
 - [Injective](./injective.md)
 - [Juno](./juno.md)
 - [Kujira](./kujira.md)

--- a/docs/src/chains/index.md
+++ b/docs/src/chains/index.md
@@ -3,6 +3,7 @@
 cw-orchestrator currently explicitly supports the chains in this section:
 
 - [Archway](./archway.md)
+- [Cosmos](./cosmos.md)
 - [Injective](./injective.md)
 - [Juno](./juno.md)
 - [Kujira](./kujira.md)

--- a/packages/cw-orch-networks/src/networks/cosmos.rs
+++ b/packages/cw-orch-networks/src/networks/cosmos.rs
@@ -18,7 +18,7 @@ pub const THETA_TESTNET_001: ChainInfo = ChainInfo {
     gas_price: 0.0025,
     grpc_urls: &["https://grpc-t.cosmos.nodestake.top:443"],
     network_info: COSMOS_HUB_NETWORK,
-    lcd_url: None,
+    lcd_url: Some("https://api-t.cosmos.nodestake.top:443"),
     fcd_url: None,
 };
 

--- a/packages/cw-orch-networks/src/networks/cosmos.rs
+++ b/packages/cw-orch-networks/src/networks/cosmos.rs
@@ -9,6 +9,8 @@ pub const COSMOS_HUB_NETWORK: NetworkInfo = NetworkInfo {
 
 pub const COSMOS_HUB_TESTNET: ChainInfo = THETA_TESTNET_001;
 
+/// Cosmos Hub Testnet
+/// @see https://github.com/cosmos/testnets/tree/master/release
 pub const THETA_TESTNET_001: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
     chain_id: "theta-testnet-001",

--- a/packages/cw-orch-networks/src/networks/cosmos.rs
+++ b/packages/cw-orch-networks/src/networks/cosmos.rs
@@ -1,0 +1,23 @@
+use cw_orch_core::environment::{ChainInfo, ChainKind, NetworkInfo};
+
+// ANCHOR: cosmos
+pub const COSMOS_NETWORK: NetworkInfo = NetworkInfo {
+    chain_name: "cosmoshub",
+    pub_address_prefix: "cosmos",
+    coin_type: 118,
+};
+
+pub const COSMOS_TESTNET: ChainInfo = THETA_TESTNET_001;
+
+pub const THETA_TESTNET_001: ChainInfo = ChainInfo {
+    kind: ChainKind::Testnet,
+    chain_id: "theta-testnet-001",
+    gas_denom: "uatom",
+    gas_price: 0.0025,
+    grpc_urls: &["https://grpc-t.cosmos.nodestake.top:443"],
+    network_info: COSMOS_NETWORK,
+    lcd_url: None,
+    fcd_url: None,
+};
+
+// ANCHOR_END: cosmos

--- a/packages/cw-orch-networks/src/networks/cosmos.rs
+++ b/packages/cw-orch-networks/src/networks/cosmos.rs
@@ -1,13 +1,13 @@
 use cw_orch_core::environment::{ChainInfo, ChainKind, NetworkInfo};
 
 // ANCHOR: cosmos
-pub const COSMOS_NETWORK: NetworkInfo = NetworkInfo {
+pub const COSMOS_HUB_NETWORK: NetworkInfo = NetworkInfo {
     chain_name: "cosmoshub",
     pub_address_prefix: "cosmos",
     coin_type: 118,
 };
 
-pub const COSMOS_TESTNET: ChainInfo = THETA_TESTNET_001;
+pub const COSMOS_HUB_TESTNET: ChainInfo = THETA_TESTNET_001;
 
 pub const THETA_TESTNET_001: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
@@ -15,7 +15,7 @@ pub const THETA_TESTNET_001: ChainInfo = ChainInfo {
     gas_denom: "uatom",
     gas_price: 0.0025,
     grpc_urls: &["https://grpc-t.cosmos.nodestake.top:443"],
-    network_info: COSMOS_NETWORK,
+    network_info: COSMOS_HUB_NETWORK,
     lcd_url: None,
     fcd_url: None,
 };

--- a/packages/cw-orch-networks/src/networks/cosmos.rs
+++ b/packages/cw-orch-networks/src/networks/cosmos.rs
@@ -7,18 +7,19 @@ pub const COSMOS_HUB_NETWORK: NetworkInfo = NetworkInfo {
     coin_type: 118,
 };
 
-pub const COSMOS_HUB_TESTNET: ChainInfo = THETA_TESTNET_001;
+pub const COSMOS_HUB_TESTNET: ChainInfo = ICS_TESTNET;
 
 /// Cosmos Hub Testnet
-/// @see https://github.com/cosmos/testnets/tree/master/release
-pub const THETA_TESTNET_001: ChainInfo = ChainInfo {
+/// @see https://github.com/cosmos/testnets/blob/master/interchain-security/provider/README.md
+/// Use the faucet here: https://faucet.polypore.xyz
+pub const ICS_TESTNET: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
-    chain_id: "theta-testnet-001",
+    chain_id: "provider",
     gas_denom: "uatom",
     gas_price: 0.0025,
-    grpc_urls: &["https://grpc-t.cosmos.nodestake.top:443"],
+    grpc_urls: &["https://grpc-rs.cosmos.nodestake.top:443"],
     network_info: COSMOS_HUB_NETWORK,
-    lcd_url: Some("https://api-t.cosmos.nodestake.top:443"),
+    lcd_url: Some("https://api-rs.cosmos.nodestake.top:443"),
     fcd_url: None,
 };
 


### PR DESCRIPTION
### Checklist

Adds the Cosmos hub testnet with details from https://github.com/cosmos/testnets/blob/master/interchain-security/provider/README.md

- [ ] Changelog updated.
- [ ] Docs updated.
