### PR TITLE
Fix/add load state from state file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { version = "1.39", features = ["full"] }
 
 cw-orch = { path = "./cw-orch", version = "0.26.0" }
 cw-orch-daemon = { path = "./cw-orch-daemon", version = "0.27.0" }
-cw-orch-core = { path = "packages/cw-orch-core", version = "2.1.0" }
+cw-orch-core = { path = "packages/cw-orch-core", version = "2.1.3" }
 cw-orch-traits = { path = "packages/cw-orch-traits", version = "0.24.0" }
 cw-orch-mock = { path = "packages/cw-orch-mock", version = "0.24.2" }
 cw-orch-networks = { path = "packages/cw-orch-networks", version = "0.24.3" }

--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-daemon"
-version = "0.27.2"
+version = "0.27.3"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -143,6 +143,10 @@ impl<Sender> ChainState for DaemonBase<Sender> {
     fn state(&self) -> Self::Out {
         self.daemon.state.clone()
     }
+
+    fn can_load_state_from_state_file(&self) -> bool {
+        true
+    }
 }
 
 // Execute on the real chain, returns tx response

--- a/packages/clone-testing/Cargo.toml
+++ b/packages/clone-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-clone-testing"
-version = "0.8.0"
+version = "0.8.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/packages/clone-testing/src/core.rs
+++ b/packages/clone-testing/src/core.rs
@@ -271,6 +271,10 @@ impl<S: StateInterface> ChainState for CloneTesting<S> {
     fn state(&self) -> Self::Out {
         self.state.clone()
     }
+
+    fn can_load_state_from_state_file(&self) -> bool {
+        true
+    }
 }
 
 // Execute on the test chain, returns test response type

--- a/packages/cw-orch-core/Cargo.toml
+++ b/packages/cw-orch-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-core"
-version = "2.1.2"
+version = "2.1.3"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/cw-orch-core/src/environment/state.rs
+++ b/packages/cw-orch-core/src/environment/state.rs
@@ -11,6 +11,12 @@ pub trait ChainState {
     type Out: StateInterface;
     /// Get the underlying state.
     fn state(&self) -> Self::Out;
+    /// Returns wether this environment can load state from the state file.
+    ///
+    /// This can be used within the Deploy trait to load the contracts from file if necessary
+    fn can_load_state_from_state_file(&self) -> bool {
+        false
+    }
 }
 
 /// This Interface allows for managing the local state of a deployment on any CosmWasm-supported environment.

--- a/packages/cw-orch-networks/Cargo.toml
+++ b/packages/cw-orch-networks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-networks"
-version = "0.24.5"
+version = "0.24.6"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/cw-orch-networks/src/networks/cosmos.rs
+++ b/packages/cw-orch-networks/src/networks/cosmos.rs
@@ -16,7 +16,7 @@ pub const ICS_TESTNET: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
     chain_id: "provider",
     gas_denom: "uatom",
-    gas_price: 0.0025,
+    gas_price: 0.01,
     grpc_urls: &["https://grpc-rs.cosmos.nodestake.top:443"],
     network_info: COSMOS_HUB_NETWORK,
     lcd_url: Some("https://api-rs.cosmos.nodestake.top:443"),


### PR DESCRIPTION
This PR aims at adding a method on ChainState to indicate whether the environment load state from state file or is just an in-memory environment.

This is used to load state from file ONLY in the case we need it (Daemon, CloneTesting) and not when we don't need it (Mock)

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
