### PR TITLE
Added custom reconnect service

### DIFF
--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -78,6 +78,8 @@ uid = "0.1.7"
 toml = "0.8"
 http = "1.1.0"
 libc-print = "0.1.23"
+tower = { version = "0.5.1", features = ["reconnect"] }
+pin-project-lite = "0.2.15"
 
 [dev-dependencies]
 cw-orch-daemon = { path = "." }

--- a/cw-orch-daemon/examples/manual_sender.rs
+++ b/cw-orch-daemon/examples/manual_sender.rs
@@ -18,10 +18,10 @@ use cosmrs::{AccountId, Any};
 use cosmwasm_std::Addr;
 use cw_orch::prelude::*;
 use cw_orch_core::environment::ChainInfoOwned;
+use cw_orch_daemon::Channel;
 use prost::Message;
 use std::io::{self, Write};
 use std::sync::Arc;
-use tonic::transport::Channel;
 
 // ANCHOR: full_counter_example
 use counter_contract::CounterContract;
@@ -72,7 +72,7 @@ impl SenderBuilder for ManualSenderOptions {
     type Sender = ManualSender;
 
     async fn build(&self, chain_info: &Arc<ChainInfoOwned>) -> Result<ManualSender, Self::Error> {
-        let grpc_channel = GrpcChannel::from_chain_info(chain_info.as_ref()).await?;
+        let grpc_channel = GrpcChannel::from_chain_info(chain_info.as_ref()).await;
         Ok(ManualSender {
             chain_info: chain_info.clone(),
             sender: Addr::unchecked(self.sender_address.clone()),
@@ -85,7 +85,7 @@ impl QuerySender for ManualSender {
     type Error = DaemonError;
     type Options = ManualSenderOptions;
 
-    fn channel(&self) -> tonic::transport::Channel {
+    fn channel(&self) -> Channel {
         self.grpc_channel.clone()
     }
 }

--- a/cw-orch-daemon/examples/querier-daemon.rs
+++ b/cw-orch-daemon/examples/querier-daemon.rs
@@ -1,5 +1,7 @@
 // ANCHOR: full_counter_example
 
+use std::{thread::sleep, time::Duration};
+
 use cw_orch::{anyhow, prelude::*};
 use cw_orch_daemon::senders::QueryOnlyDaemon;
 
@@ -17,6 +19,16 @@ pub fn main() -> anyhow::Result<()> {
         .bank_querier()
         .balance(&Addr::unchecked(LOCAL_JUNO_SENDER), None)?;
     assert!(!balances.is_empty());
+
+    log::info!("Sleeping 10s");
+    sleep(Duration::from_secs(10));
+    log::info!("FInished sleeping");
+
+    let balances = chain
+        .bank_querier()
+        .balance(&Addr::unchecked(LOCAL_JUNO_SENDER), None)?;
+    assert!(!balances.is_empty());
+    log::info!("Finished example");
 
     Ok(())
 }

--- a/cw-orch-daemon/src/core.rs
+++ b/cw-orch-daemon/src/core.rs
@@ -1,6 +1,7 @@
 use super::{
     cosmos_modules, error::DaemonError, queriers::Node, senders::Wallet, tx_resp::CosmTxResponse,
 };
+use crate::Channel;
 use crate::{
     queriers::CosmWasm,
     senders::{builder::SenderBuilder, query::QuerySender, tx::TxSender},
@@ -31,7 +32,6 @@ use std::{
     str::{from_utf8, FromStr},
     time::Duration,
 };
-use tonic::transport::Channel;
 
 pub const INSTANTIATE_2_TYPE_URL: &str = "/cosmwasm.wasm.v1.MsgInstantiateContract2";
 

--- a/cw-orch-daemon/src/lib.rs
+++ b/cw-orch-daemon/src/lib.rs
@@ -12,6 +12,7 @@ pub mod keys;
 pub mod live_mock;
 pub mod queriers;
 pub mod senders;
+pub mod service;
 pub mod tx_broadcaster;
 pub mod tx_builder;
 

--- a/cw-orch-daemon/src/live_mock.rs
+++ b/cw-orch-daemon/src/live_mock.rs
@@ -4,6 +4,7 @@
 use crate::queriers::Bank;
 use crate::queriers::CosmWasm;
 use crate::queriers::Staking;
+use crate::Channel;
 use crate::RUNTIME;
 use cosmwasm_std::testing::{MockApi, MockStorage};
 use cosmwasm_std::Addr;
@@ -24,7 +25,6 @@ use cw_orch_core::environment::ChainInfoOwned;
 use cw_orch_core::environment::WasmQuerier;
 use std::marker::PhantomData;
 use std::str::FromStr;
-use tonic::transport::Channel;
 
 use crate::channel::GrpcChannel;
 
@@ -191,12 +191,10 @@ impl WasmMockQuerier {
 impl WasmMockQuerier {
     /// Creates a querier from chain information
     pub fn new(chain: ChainInfoOwned) -> Self {
-        let channel = RUNTIME
-            .block_on(GrpcChannel::connect(
-                &chain.grpc_urls,
-                chain.chain_id.as_str(),
-            ))
-            .unwrap();
+        let channel = RUNTIME.block_on(GrpcChannel::connect(
+            &chain.grpc_urls,
+            chain.chain_id.as_str(),
+        ));
 
         WasmMockQuerier { channel }
     }

--- a/cw-orch-daemon/src/queriers/authz.rs
+++ b/cw-orch-daemon/src/queriers/authz.rs
@@ -3,7 +3,7 @@ use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmwasm_std::Addr;
 use cw_orch_core::environment::{Querier, QuerierGetter};
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
+use crate::Channel;
 
 /// Queries for Cosmos AuthZ Module
 /// All the async function are prefixed with `_`

--- a/cw-orch-daemon/src/queriers/bank.rs
+++ b/cw-orch-daemon/src/queriers/bank.rs
@@ -3,7 +3,7 @@ use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmwasm_std::{Addr, Coin, StdError};
 use cw_orch_core::environment::{BankQuerier, Querier, QuerierGetter};
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
+use crate::Channel;
 
 /// Queries for Cosmos Bank Module
 /// All the async function are prefixed with `_`

--- a/cw-orch-daemon/src/queriers/cosmwasm.rs
+++ b/cw-orch-daemon/src/queriers/cosmwasm.rs
@@ -2,6 +2,7 @@ use std::{marker::PhantomData, str::FromStr};
 
 use crate::senders::query::QuerySender;
 use crate::senders::QueryOnlySender;
+use crate::Channel;
 use crate::{cosmos_modules, error::DaemonError, DaemonBase};
 use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmrs::AccountId;
@@ -15,7 +16,6 @@ use cw_orch_core::{
     environment::{Querier, QuerierGetter, WasmQuerier},
 };
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
 
 /// Querier for the CosmWasm SDK module
 /// All the async function are prefixed with `_`

--- a/cw-orch-daemon/src/queriers/feegrant.rs
+++ b/cw-orch-daemon/src/queriers/feegrant.rs
@@ -1,9 +1,9 @@
+use crate::Channel;
 use crate::{cosmos_modules, error::DaemonError, Daemon};
 use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmwasm_std::Addr;
 use cw_orch_core::environment::{Querier, QuerierGetter};
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
 
 /// Querier for the Cosmos Gov module
 /// All the async function are prefixed with `_`

--- a/cw-orch-daemon/src/queriers/gov.rs
+++ b/cw-orch-daemon/src/queriers/gov.rs
@@ -3,7 +3,7 @@ use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmwasm_std::Addr;
 use cw_orch_core::environment::{Querier, QuerierGetter};
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
+use crate::Channel;
 
 /// Querier for the Cosmos Gov module
 /// All the async function are prefixed with `_`

--- a/cw-orch-daemon/src/queriers/ibc.rs
+++ b/cw-orch-daemon/src/queriers/ibc.rs
@@ -1,3 +1,4 @@
+use crate::Channel;
 use crate::{cosmos_modules, error::DaemonError, Daemon};
 use cosmos_modules::ibc_channel;
 use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
@@ -13,8 +14,6 @@ use cosmrs::proto::ibc::{
 use cw_orch_core::environment::{Querier, QuerierGetter};
 use prost::Message;
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
-
 /// Querier for the Cosmos IBC module
 /// All the async function are prefixed with `_`
 pub struct Ibc {

--- a/cw-orch-daemon/src/queriers/node.rs
+++ b/cw-orch-daemon/src/queriers/node.rs
@@ -5,6 +5,7 @@ use crate::{
     tx_resp::CosmTxResponse, DaemonBase,
 };
 
+use crate::Channel;
 use cosmrs::{
     proto::cosmos::{
         base::query::v1beta1::PageRequest,
@@ -18,8 +19,6 @@ use cw_orch_core::{
     log::query_target,
 };
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
-
 /// Querier for the Tendermint node.
 /// Supports queries for block and tx information
 /// All the async function are prefixed with `_`

--- a/cw-orch-daemon/src/queriers/staking.rs
+++ b/cw-orch-daemon/src/queriers/staking.rs
@@ -1,11 +1,11 @@
 use std::fmt::Display;
 
+use crate::Channel;
 use crate::{cosmos_modules, error::DaemonError, Daemon};
 use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
 use cosmwasm_std::{Addr, StdError};
 use cw_orch_core::environment::{Querier, QuerierGetter};
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
 
 use super::bank::cosmrs_to_cosmwasm_coin;
 

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -4,6 +4,7 @@ use super::{
     sign::{Signer, SigningAccount},
     tx::TxSender,
 };
+use crate::Channel;
 use crate::{
     core::parse_cw_coins,
     cosmos_modules::{self, auth::BaseAccount},
@@ -33,7 +34,6 @@ use cw_orch_core::{
     CoreEnvVars, CwEnvError,
 };
 use std::{str::FromStr, sync::Arc};
-use tonic::transport::Channel;
 
 #[cfg(feature = "eth")]
 use crate::proto::injective::InjectiveSigner;
@@ -98,7 +98,7 @@ impl Wallet {
 
         Ok(Self {
             chain_info: chain_info.clone(),
-            grpc_channel: GrpcChannel::from_chain_info(chain_info.as_ref()).await?,
+            grpc_channel: GrpcChannel::from_chain_info(chain_info.as_ref()).await,
             private_key: pk,
             secp,
             options,

--- a/cw-orch-daemon/src/senders/cosmos_batch.rs
+++ b/cw-orch-daemon/src/senders/cosmos_batch.rs
@@ -1,4 +1,4 @@
-use crate::{DaemonBase, INSTANTIATE_2_TYPE_URL};
+use crate::{Channel, DaemonBase, INSTANTIATE_2_TYPE_URL};
 
 use crate::{error::DaemonError, tx_resp::CosmTxResponse};
 
@@ -86,7 +86,7 @@ impl QuerySender for CosmosBatchSender {
     type Error = DaemonError;
     type Options = CosmosBatchOptions;
 
-    fn channel(&self) -> tonic::transport::Channel {
+    fn channel(&self) -> Channel {
         self.sender.channel()
     }
 }

--- a/cw-orch-daemon/src/senders/query.rs
+++ b/cw-orch-daemon/src/senders/query.rs
@@ -1,4 +1,4 @@
-use tonic::transport::Channel;
+use crate::Channel;
 
 use crate::DaemonError;
 

--- a/cw-orch-daemon/src/senders/query_only.rs
+++ b/cw-orch-daemon/src/senders/query_only.rs
@@ -4,7 +4,7 @@ use crate::{error::DaemonError, DaemonBase, GrpcChannel};
 
 use cw_orch_core::environment::ChainInfoOwned;
 
-use tonic::transport::Channel;
+use crate::Channel;
 
 use super::{builder::SenderBuilder, query::QuerySender};
 
@@ -26,7 +26,7 @@ impl SenderBuilder for () {
     type Sender = QueryOnlySender;
 
     async fn build(&self, chain_info: &Arc<ChainInfoOwned>) -> Result<Self::Sender, Self::Error> {
-        let channel = GrpcChannel::from_chain_info(chain_info.as_ref()).await?;
+        let channel = GrpcChannel::from_chain_info(chain_info.as_ref()).await;
 
         Ok(QueryOnlySender {
             channel,

--- a/cw-orch-daemon/src/service/factory.rs
+++ b/cw-orch-daemon/src/service/factory.rs
@@ -1,0 +1,28 @@
+use std::{future::Future, pin::Pin};
+
+use tower::Service;
+
+use crate::{DaemonError, GrpcChannel};
+
+pub type ChannelCreationArgs = (Vec<String>, String);
+#[derive(Clone)]
+pub struct ChannelFactory {}
+
+impl Service<ChannelCreationArgs> for ChannelFactory {
+    type Response = tonic::transport::Channel;
+
+    type Error = DaemonError;
+
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: ChannelCreationArgs) -> Self::Future {
+        Box::pin(async move { GrpcChannel::get_channel(req.0.as_ref(), &req.1).await })
+    }
+}

--- a/cw-orch-daemon/src/service/future.rs
+++ b/cw-orch-daemon/src/service/future.rs
@@ -1,0 +1,74 @@
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::BoxError;
+
+pin_project! {
+    /// Future that resolves to the response or failure to connect.
+    #[derive(Debug)]
+    pub struct ResponseFuture<F, E> {
+        #[pin]
+        inner: Inner<F, E>,
+    }
+}
+
+pin_project! {
+    #[project = InnerProj]
+    #[derive(Debug)]
+    enum Inner<F, E> {
+        Future {
+            #[pin]
+            fut: F,
+        },
+        Error {
+            error: Option<E>,
+        },
+    }
+}
+
+impl<F, E> Inner<F, E> {
+    fn future(fut: F) -> Self {
+        Self::Future { fut }
+    }
+
+    fn error(error: Option<E>) -> Self {
+        Self::Error { error }
+    }
+}
+
+impl<F, E> ResponseFuture<F, E> {
+    pub(crate) fn new(inner: F) -> Self {
+        ResponseFuture {
+            inner: Inner::future(inner),
+        }
+    }
+
+    pub(crate) fn error(error: E) -> Self {
+        ResponseFuture {
+            inner: Inner::error(Some(error)),
+        }
+    }
+}
+
+impl<F, T, E, ME> Future for ResponseFuture<F, ME>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<BoxError>,
+    ME: Into<BoxError>,
+{
+    type Output = Result<T, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.project();
+        match me.inner.project() {
+            InnerProj::Future { fut } => fut.poll(cx).map_err(Into::into),
+            InnerProj::Error { error } => {
+                let e = error.take().expect("Polled after ready.").into();
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+}

--- a/cw-orch-daemon/src/service/mod.rs
+++ b/cw-orch-daemon/src/service/mod.rs
@@ -1,0 +1,3 @@
+pub mod factory;
+pub mod future;
+pub mod reconnect;

--- a/cw-orch-daemon/src/service/reconnect.rs
+++ b/cw-orch-daemon/src/service/reconnect.rs
@@ -1,0 +1,190 @@
+use crate::service::future::ResponseFuture;
+use crate::DaemonError;
+use log::trace;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::Duration;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{BoxError, Service};
+
+use super::factory::ChannelFactory;
+
+/// Reconnect to failed services.
+pub struct Reconnect<M, Target>
+where
+    M: Service<Target>,
+    M::Error: std::fmt::Debug,
+
+    M: Sync,
+    Target: Sync,
+{
+    mk_service: M,
+    state: Arc<Mutex<State<M::Future, M::Response, M::Error>>>,
+    target: Target,
+}
+
+impl<M, Target> Clone for Reconnect<M, Target>
+where
+    M: Service<Target>,
+    M::Error: std::fmt::Debug,
+    M: Clone,
+    Target: Clone,
+    M: Sync,
+    Target: Sync,
+{
+    fn clone(&self) -> Self {
+        Self {
+            mk_service: self.mk_service.clone(),
+            state: self.state.clone(),
+            target: self.target.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum State<F, S, E: std::fmt::Debug> {
+    Error(E),
+    Idle,
+    Connecting(F),
+    Connected(S),
+}
+
+impl<M, Target> Reconnect<M, Target>
+where
+    M: Service<Target>,
+    M::Error: std::fmt::Debug,
+    M: Sync,
+    Target: Sync,
+{
+    /// Lazily connect and reconnect to a [`Service`].
+    pub fn new(mk_service: M, target: Target) -> Self {
+        Reconnect {
+            mk_service,
+            state: Arc::new(Mutex::new(State::Idle)),
+            target,
+        }
+    }
+
+    /// Reconnect to a already connected [`Service`].
+    pub fn with_connection(init_conn: M::Response, mk_service: M, target: Target) -> Self {
+        Reconnect {
+            mk_service,
+            state: Arc::new(Mutex::new(State::Connected(init_conn))),
+            target,
+        }
+    }
+}
+
+impl<Target, S, Request> Service<Request> for Reconnect<ChannelFactory, Target>
+where
+    ChannelFactory: Service<Target, Response = S>,
+    <ChannelFactory as Service<Target>>::Error: std::fmt::Debug,
+    <ChannelFactory as Service<Target>>::Future: Unpin,
+    BoxError: From<<ChannelFactory as Service<Target>>::Error> + From<S::Error>,
+
+    S: Service<Request>,
+    Target: Clone + Sync,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = ResponseFuture<S::Future, DaemonError>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        loop {
+            let mut state = self.state.lock().unwrap();
+            match &mut *state {
+                State::Idle | State::Error(_) => {
+                    trace!("poll_ready; idle");
+                    match self.mk_service.poll_ready(cx) {
+                        Poll::Ready(r) => r?,
+                        Poll::Pending => {
+                            trace!("poll_ready; MakeService not ready");
+                            return Poll::Pending;
+                        }
+                    }
+
+                    let fut = self.mk_service.call(self.target.clone());
+                    drop(state);
+                    self.state = Arc::new(Mutex::new(State::Connecting(fut)));
+                    continue;
+                }
+                State::Connecting(ref mut f) => {
+                    trace!("poll_ready; connecting");
+                    match Pin::new(f).poll(cx) {
+                        Poll::Ready(Ok(service)) => {
+                            drop(state);
+                            self.state = Arc::new(Mutex::new(State::Connected(service)));
+                        }
+                        Poll::Pending => {
+                            trace!("poll_ready; not ready");
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(e)) => {
+                            trace!("poll_ready; error, retrying in {} seconds", 5);
+                            drop(state);
+                            self.state = Arc::new(Mutex::new(State::Error(e)));
+                            sleep(Duration::from_secs(5));
+                        }
+                    }
+                }
+                State::Connected(ref mut inner) => {
+                    trace!("poll_ready; connected");
+                    match inner.poll_ready(cx) {
+                        Poll::Ready(Ok(())) => {
+                            trace!("poll_ready; ready");
+                            return Poll::Ready(Ok(()));
+                        }
+                        Poll::Pending => {
+                            trace!("poll_ready; not ready");
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(_)) => {
+                            trace!("poll_ready; error");
+
+                            drop(state);
+                            self.state = Arc::new(Mutex::new(State::Idle));
+                        }
+                    }
+                }
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let mut state = self.state.lock().unwrap();
+        let service = match &mut *state {
+            State::Connected(ref mut service) => service,
+            State::Error(error) => panic!("{:?}", error),
+            _ => panic!("service not ready; poll_ready must be called first"),
+        };
+
+        let fut = service.call(request);
+        ResponseFuture::new(fut)
+    }
+}
+
+impl<M, Target> fmt::Debug for Reconnect<M, Target>
+where
+    M: Service<Target> + fmt::Debug,
+    M::Future: fmt::Debug,
+    M::Response: fmt::Debug,
+    Target: fmt::Debug,
+    M::Error: std::fmt::Debug,
+    M: Sync,
+    Target: Sync,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Reconnect")
+            .field("mk_service", &self.mk_service)
+            .field("state", &self.state)
+            .field("target", &self.target)
+            .finish()
+    }
+}

--- a/cw-orch-daemon/src/sync/core.rs
+++ b/cw-orch-daemon/src/sync/core.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, ops::DerefMut};
 
 use super::super::senders::Wallet;
+use crate::Channel;
 use crate::{
     queriers::{Bank, CosmWasmBase, Node},
     senders::{builder::SenderBuilder, query::QuerySender},
@@ -14,7 +15,6 @@ use cw_orch_core::{
 use cw_orch_traits::stargate::Stargate;
 use serde::Serialize;
 use tokio::runtime::Handle;
-use tonic::transport::Channel;
 
 use crate::senders::tx::TxSender;
 

--- a/packages/interchain/interchain-core/src/channel.rs
+++ b/packages/interchain/interchain-core/src/channel.rs
@@ -12,7 +12,7 @@ use crate::InterchainError;
 
 /// Identifies a channel between two IBC connected chains.
 /// This describes only 1 side of the channel
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct IbcPort<Channel> {
     /// The chain id of the network which belongs on one side of the channel
     pub chain_id: NetworkId,
@@ -31,10 +31,21 @@ pub struct IbcPort<Channel> {
     pub chain: Channel,
 }
 
+impl<Channel> std::fmt::Debug for IbcPort<Channel> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IbcPort")
+            .field("chain_id", &self.chain_id)
+            .field("connection_id", &self.connection_id)
+            .field("port", &self.port)
+            .field("channel", &self.channel)
+            .finish()
+    }
+}
+
 /// Store information about a channel between 2 blockchains
 /// The order of port_a and port_b is not important
 /// Even if there is a src and dst chain, the order for an IBC channel doesn't matter
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct InterchainChannel<Channel>
 where
     Channel: Clone + Send + Sync,
@@ -43,6 +54,18 @@ where
     pub port_a: IbcPort<Channel>,
     /// Port on the other side of the channel
     pub port_b: IbcPort<Channel>,
+}
+
+impl<Channel> std::fmt::Debug for InterchainChannel<Channel>
+where
+    Channel: Clone + Send + Sync,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InterchainChannel")
+            .field("port_a", &self.port_a)
+            .field("port_b", &self.port_b)
+            .finish()
+    }
 }
 
 // TODO some of those queries may be implemented (or are already implemented) in the IBC querier file ?

--- a/packages/interchain/interchain-core/src/ibc_query.rs
+++ b/packages/interchain/interchain-core/src/ibc_query.rs
@@ -2,6 +2,7 @@ use crate::results::NetworkId;
 use cosmwasm_std::Api;
 use cw_orch_core::environment::CwEnv;
 use cw_orch_core::environment::QueryHandler;
+use cw_orch_daemon::Channel;
 use cw_orch_mock::{MockBase, MockState};
 
 /// Adds additional capabilities to CwEnv for use with ibc environments
@@ -20,9 +21,9 @@ pub trait IbcQueryHandler: CwEnv {
 #[cfg(feature = "daemon")]
 // Temporary until we can actually push to cw-orch-daemon
 impl IbcQueryHandler for cw_orch_daemon::Daemon {
-    type Handler = tonic::transport::Channel;
+    type Handler = Channel;
 
-    fn ibc_handler(&self) -> tonic::transport::Channel {
+    fn ibc_handler(&self) -> Channel {
         self.channel()
     }
 

--- a/packages/interchain/interchain-daemon/src/error.rs
+++ b/packages/interchain/interchain-daemon/src/error.rs
@@ -1,9 +1,9 @@
 #![allow(missing_docs)]
 
 use cosmwasm_std::StdError;
+use cw_orch_daemon::Channel;
 use cw_orch_interchain_core::{channel::InterchainChannel, results::NetworkId, InterchainError};
 use thiserror::Error;
-use tonic::transport::Channel;
 
 #[derive(Error, Debug)]
 pub enum InterchainDaemonError {

--- a/packages/interchain/interchain-daemon/src/ibc_tracker.rs
+++ b/packages/interchain/interchain-daemon/src/ibc_tracker.rs
@@ -5,7 +5,7 @@ use cosmrs::proto::ibc::core::channel::v1::State;
 use cw_orch_core::contract::interface_traits::ContractInstance;
 use cw_orch_core::environment::Environment;
 use cw_orch_daemon::queriers::{Ibc, Node};
-use cw_orch_daemon::Daemon;
+use cw_orch_daemon::{Channel, Daemon};
 use cw_orch_interchain_core::env::contract_port;
 use diff::Diff;
 use futures_util::future::join_all;
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::{fmt::Display, time::Duration};
-use tonic::{async_trait, transport::Channel};
+use tonic::async_trait;
 
 use self::logged_state::LoggedState;
 
@@ -117,8 +117,9 @@ mod logged_state {
         fmt::{Debug, Display},
     };
 
+    use cw_orch_daemon::Channel;
     use diff::Diff;
-    use tonic::{async_trait, transport::Channel};
+    use tonic::async_trait;
 
     #[async_trait]
     pub trait LoggedState:

--- a/packages/interchain/interchain-daemon/src/interchain_env.rs
+++ b/packages/interchain/interchain-daemon/src/interchain_env.rs
@@ -6,9 +6,9 @@ use cw_orch_interchain_core::channel::{IbcPort, InterchainChannel};
 use cw_orch_interchain_core::env::{ChainId, ChannelCreation};
 use cw_orch_interchain_core::{InterchainEnv, NestedPacketsFlow, SinglePacketFlow};
 
+use cw_orch_daemon::Channel;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use tokio::time::sleep;
-use tonic::transport::Channel;
 
 use crate::channel_creator::{ChannelCreationValidator, ChannelCreator};
 use crate::interchain_log::InterchainLog;

--- a/packages/interchain/interchain-daemon/src/packet_inspector.rs
+++ b/packages/interchain/interchain-daemon/src/packet_inspector.rs
@@ -18,10 +18,10 @@ use futures_util::FutureExt;
 use crate::{IcDaemonResult, InterchainDaemonError};
 use cw_orch_interchain_core::results::NetworkId;
 
+use cw_orch_daemon::Channel;
 use futures::future::try_join_all;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
-use tonic::transport::Channel;
 
 use std::collections::HashMap;
 
@@ -176,7 +176,7 @@ impl PacketInspector {
         } else {
             // If no custom channel was registered, we try to get it from the registry
             let chain_data: ChainInfoOwned = parse_network(chain_id).unwrap().into(); // TODO, no unwrap here ?
-            Ok(GrpcChannel::connect(&chain_data.grpc_urls, chain_id).await?)
+            Ok(GrpcChannel::connect(&chain_data.grpc_urls, chain_id).await)
         }
     }
 

--- a/packages/interchain/proto/Cargo.toml
+++ b/packages/interchain/proto/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 cw-orch-interchain-core = { workspace = true }
 cw-orch-traits = { workspace = true }
 cw-orch-core = { workspace = true }
+cw-orch-daemon = { workspace = true }
 
 anyhow = { workspace = true }
 

--- a/packages/interchain/proto/src/tokenfactory.rs
+++ b/packages/interchain/proto/src/tokenfactory.rs
@@ -1,12 +1,12 @@
 #![allow(non_snake_case)]
 
+use cw_orch_daemon::Channel;
 use cw_orch_interchain_core::{
     channel::InterchainChannel, IbcQueryHandler, InterchainEnv, InterchainError, NestedPacketsFlow,
 };
 use ibc_proto::ibc::apps::transfer::v1::MsgTransfer;
 use osmosis_std::types::osmosis::tokenfactory::v1beta1::{MsgCreateDenom, MsgMint};
 use prost::{Message, Name};
-use tonic::transport::Channel;
 
 use cosmwasm_std::Coin;
 use cw_orch_core::environment::{CwEnv, TxHandler};


### PR DESCRIPTION
This PR aims at adding a reconnect and retry layer for the tonic::transport::Channel that suits our needs. 


- [x] Reconnect Layer that never errors. This could be changed to allow a certain number of errors or whatever good practive is in this kind of case
- [ ] Retry is not yet implemented because it requires copying the request, which is not easy (http::Request<BoxBody>). This PR could help us: https://github.com/tower-rs/tower/pull/790

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
