### PR TITLE
cw-orch-cli change version to 0.2.3

### DIFF
--- a/cw-orch-cli/Cargo.toml
+++ b/cw-orch-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-cli"
-version = "0.2.4"
+version = "0.2.3"
 authors = ["Buckram <misha@abstract.money>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
0.2.3 was never released, but there is no breaking changes from 0.2.2