### PR TITLE
Added ics hook

### DIFF
--- a/packages/interchain/interchain-core/Cargo.toml
+++ b/packages/interchain/interchain-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-orch-interchain-core"
-version = "0.9.1"
+version = "0.9.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/packages/interchain/interchain-core/src/ack_parser.rs
+++ b/packages/interchain/interchain-core/src/ack_parser.rs
@@ -86,7 +86,7 @@ impl IbcAckParser {
     /// Returns an error if there was an error in the parsing process
     ///
     /// The structure can be found here : https://github.com/cosmos/ibc-apps/blob/8cb681e31589bc90b47e0ab58173a579825fd56d/modules/ibc-hooks/wasm_hook.go#L119C1-L119C86
-    pub fn ics_hooks_ack(ack: &Binary) -> Result<IbcHooksAck, InterchainError> {
+    pub fn ibc_hooks_ack(ack: &Binary) -> Result<IbcHooksAck, InterchainError> {
         if let Ok(decoded_ics_ack) = from_json::<IbcHooksAck>(ack) {
             return Ok(decoded_ics_ack);
         }
@@ -123,7 +123,7 @@ impl IbcAckParser {
             Ok(IbcAppResult::Ics004(ack))
         } else if let Ok(ack) = IbcAckParser::ics004_json_ack(ack) {
             Ok(IbcAppResult::Ics004(ack))
-        } else if let Ok(ack) = IbcAckParser::ics_hooks_ack(ack) {
+        } else if let Ok(ack) = IbcAckParser::ibc_hooks_ack(ack) {
             Ok(IbcAppResult::IbcHooks(ack))
         } else {
             Err(InterchainError::AckDecodingFailed(

--- a/packages/interchain/interchain-core/src/ack_parser.rs
+++ b/packages/interchain/interchain-core/src/ack_parser.rs
@@ -123,6 +123,8 @@ impl IbcAckParser {
             Ok(IbcAppResult::Ics004(ack))
         } else if let Ok(ack) = IbcAckParser::ics004_json_ack(ack) {
             Ok(IbcAppResult::Ics004(ack))
+        } else if let Ok(ack) = IbcAckParser::ics_hooks_ack(ack) {
+            Ok(IbcAppResult::IbcHooks(ack))
         } else {
             Err(InterchainError::AckDecodingFailed(
                 ack.clone(),

--- a/packages/interchain/interchain-core/src/ack_parser.rs
+++ b/packages/interchain/interchain-core/src/ack_parser.rs
@@ -81,6 +81,19 @@ impl IbcAckParser {
         Err(decode_ack_error(ack))
     }
 
+    /// Verifies if the given ack is an ibc-hooks type and returns the ack result if it is
+    ///
+    /// Returns an error if there was an error in the parsing process
+    ///
+    /// The structure can be found here : https://github.com/cosmos/ibc-apps/blob/8cb681e31589bc90b47e0ab58173a579825fd56d/modules/ibc-hooks/wasm_hook.go#L119C1-L119C86
+    pub fn ics_hooks_ack(ack: &Binary) -> Result<IbcHooksAck, InterchainError> {
+        if let Ok(decoded_ics_ack) = from_json::<IbcHooksAck>(ack) {
+            return Ok(decoded_ics_ack);
+        }
+
+        Err(decode_ack_error(ack))
+    }
+
     /// Verifies if the given ack is an ICS004 type with json parsing and returns the ack result if it is
     ///
     /// Returns an error if there was an error in the parsing process
@@ -174,6 +187,15 @@ pub mod acknowledgement {
 pub enum StdAck {
     Result(Binary),
     Error(String),
+}
+
+/// This is the ibc-hooks acknowledgment formated in json
+/// https://github.com/cosmos/ibc-apps/blob/8cb681e31589bc90b47e0ab58173a579825fd56d/modules/ibc-hooks/wasm_hook.go#L119C1-L119C86
+
+#[cw_serde]
+pub struct IbcHooksAck {
+    contract_result: Option<Binary>,
+    ibc_ack: Binary,
 }
 
 pub mod polytone_callback {

--- a/packages/interchain/interchain-core/src/packet.rs
+++ b/packages/interchain/interchain-core/src/packet.rs
@@ -170,6 +170,7 @@ impl<Chain: CwEnv> IndexResponse for NestedPacketsFlow<Chain> {
 }
 
 pub mod success {
+    use crate::ack_parser::IbcHooksAck;
     use crate::{ack_parser::polytone_callback::Callback, tx::TxId};
     use cosmwasm_std::{Binary, Empty, StdError};
     use cw_orch_core::environment::CwEnv;
@@ -177,6 +178,7 @@ pub mod success {
 
     /// Contains the result (ack success) associated with various Ibc applications
     #[derive(Debug, PartialEq, Clone)]
+    #[non_exhaustive]
     pub enum IbcAppResult<CustomResult = Empty> {
         /// Contains a successful result for Polytone
         Polytone(Callback),
@@ -184,6 +186,9 @@ pub mod success {
         Ics20,
         /// Contains a successful result according to the ICS004 standard
         Ics004(Vec<u8>),
+        /// Contains a successful result according to the ibc hooks standard
+        /// https://github.com/cosmos/ibc-apps/blob/8cb681e31589bc90b47e0ab58173a579825fd56d/modules/ibc-hooks/wasm_hook.go#L119C1-L119C86
+        IbcHooks(IbcHooksAck),
         /// Contains a custom result. This is only used if a custom parsing function is specified
         Custom(CustomResult),
     }
@@ -195,6 +200,7 @@ pub mod success {
                 IbcAppResult::Polytone(callback) => IbcAppResult::Polytone(callback),
                 IbcAppResult::Ics20 => IbcAppResult::Ics20,
                 IbcAppResult::Ics004(vec) => IbcAppResult::Ics004(vec),
+                IbcAppResult::IbcHooks(ibc_hooks_ack) => IbcAppResult::IbcHooks(ibc_hooks_ack),
                 IbcAppResult::Custom(_) => unreachable!(),
             }
         }


### PR DESCRIPTION
This Pr aims at adding the ics hook ack into cw-orch-interchain ack parsing.
This change is breaking, but we might push the change as non-breaking because the Ack enum is barely used outside of the crate

### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
