### PR TITLE
Docs: Fixed the link to the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,4 +301,4 @@ cw-orchestrator is inspired by [terra-rust-api](https://github.com/PFC-Validator
 
 This software is licensed under LGPL-3.0. For more information, see the [LICENSE](LICENSE.LESSER) file.
 
-Versions of this software on and before commit `cbab5f51b9e0b4ddec88906e263e4290e5b2dedf`, corresponding to version `v0.25.0`, are licensed under GPL-3.0. For more information, see the [LICENSE](LICENSE) file.
+Versions of this software on and before commit `cbab5f51b9e0b4ddec88906e263e4290e5b2dedf`, corresponding to version `v0.25.0`, are licensed under GPL-3.0. For more information, see the [LICENSE](https://github.com/AbstractSDK/cw-orchestrator/blob/main/LICENCE) file.


### PR DESCRIPTION
Fixed the license link, the old one didn't work

- [ ] Changelog updated.
- [ ] Docs updated.
