### PR TITLE
assume_http2 on grpc

### DIFF
--- a/cw-orch-daemon/Cargo.toml
+++ b/cw-orch-daemon/Cargo.toml
@@ -8,7 +8,7 @@ license     = { workspace = true }
 name        = "cw-orch-daemon"
 readme      = "../README.md"
 repository  = { workspace = true }
-version     = "0.29.0"
+version     = "0.29.1"
 
 exclude = [".env"]
 

--- a/cw-orch-daemon/src/channel.rs
+++ b/cw-orch-daemon/src/channel.rs
@@ -25,7 +25,12 @@ impl GrpcChannel {
             let uri = Uri::from_maybe_shared(address.clone()).expect("Invalid URI");
 
             let maybe_channel = Endpoint::from(uri)
-                .tls_config(ClientTlsConfig::new().with_enabled_roots())
+                .tls_config(
+                    ClientTlsConfig::new()
+                        .with_enabled_roots()
+                        // grpcs are http/2 by spec
+                        .assume_http2(true),
+                )
                 .unwrap()
                 .connect()
                 .await;


### PR DESCRIPTION
Grpc connection should be always http2 on any nodes