### PR TITLE
Fix Authz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,6 @@ log = "0.4.22"
 # Interchain
 ibc-chain-registry = { version = "0.29.2" }
 ibc-relayer-types  = { version = "0.29.2" }
+
+# 4.1.0 is breaking
+ed25519-zebra = "=4.0.3"

--- a/cw-orch-daemon/src/senders/cosmos.rs
+++ b/cw-orch-daemon/src/senders/cosmos.rs
@@ -30,7 +30,7 @@ use cw_orch_core::{
     environment::{AccessConfig, ChainInfoOwned, ChainKind},
     CoreEnvVars, CwEnvError,
 };
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use tonic::transport::Channel;
 
 #[cfg(feature = "eth")]
@@ -237,7 +237,7 @@ impl Wallet {
     }
 
     pub async fn base_account(&self) -> Result<BaseAccount, DaemonError> {
-        let addr = self.address().to_string();
+        let addr = self.signer_account_id().to_string();
 
         let mut client = cosmos_modules::auth::query_client::QueryClient::new(self.channel());
 
@@ -300,7 +300,7 @@ impl Wallet {
 
         // If there is not enough asset balance, we need to warn the user
         log::info!(
-            "Not enough funds on chain {} at address {} to deploy the contract. 
+            "Not enough funds on chain {} at address {} to deploy the contract.
                 Needed: {}{} but only have: {}.
                 Press 'y' when the wallet balance has been increased to resume deployment",
             chain_info.chain_id,
@@ -461,6 +461,13 @@ impl Signer for Wallet {
     }
 
     fn account_id(&self) -> AccountId {
+        match self.authz_granter() {
+            Some(granter_addr) => AccountId::from_str(granter_addr.as_str()).unwrap(),
+            None => self.signer_account_id(),
+        }
+    }
+
+    fn signer_account_id(&self) -> AccountId {
         AccountId::new(
             &self.chain_info.network_info.pub_address_prefix,
             &self.private_key.public_key(&self.secp).raw_address.unwrap(),

--- a/cw-orch-daemon/src/senders/sign.rs
+++ b/cw-orch-daemon/src/senders/sign.rs
@@ -29,8 +29,13 @@ pub trait Signer: QuerySender<Error = DaemonError> + Sync {
     /// The chain id of the connected chain
     fn chain_id(&self) -> String;
 
-    /// The account id of the signer.
+    /// The account id of the sender.
     fn account_id(&self) -> AccountId;
+
+    /// The account id of the signer, it is different from account_id with authz granter.
+    fn signer_account_id(&self) -> AccountId {
+        self.account_id()
+    }
 
     fn signing_account(
         &self,
@@ -97,7 +102,7 @@ impl<T: Signer + Sync> TxSender for T {
             vec![Any {
                 type_url: "/cosmos.authz.v1beta1.MsgExec".to_string(),
                 value: MsgExec {
-                    grantee: self.account_id().to_string(),
+                    grantee: self.signer_account_id().to_string(),
                     msgs,
                 }
                 .encode_to_vec(),
@@ -126,15 +131,6 @@ impl<T: Signer + Sync> TxSender for T {
             .await?;
 
         assert_broadcast_code_cosm_response(resp)
-    }
-    /// Actual sender of the messages.
-    /// This is different when using authz capabilites
-    fn msg_sender(&self) -> Result<AccountId, DaemonError> {
-        if let Some(sender) = self.authz_granter() {
-            Ok(sender.as_str().parse()?)
-        } else {
-            Ok(self.account_id())
-        }
     }
 
     async fn bank_send(

--- a/cw-orch-daemon/tests/authz.rs
+++ b/cw-orch-daemon/tests/authz.rs
@@ -12,10 +12,14 @@ mod tests {
         },
         bank::v1beta1::MsgSend,
     };
-    use cosmwasm_std::coins;
+    use cosmwasm_std::{coins, Addr};
     use cw_orch_core::environment::QuerierGetter;
     use cw_orch_core::environment::{BankQuerier, DefaultQueriers, QueryHandler, TxHandler};
-    use cw_orch_daemon::{queriers::Authz, senders::CosmosOptions, Daemon};
+    use cw_orch_daemon::{
+        queriers::Authz,
+        senders::{sign::Signer, CosmosOptions},
+        Daemon,
+    };
     use cw_orch_networks::networks::LOCAL_JUNO;
     use cw_orch_traits::Stargate;
     use prost::Message;
@@ -34,20 +38,27 @@ mod tests {
             .build()
             .unwrap();
 
-        let sender = daemon.sender_addr();
+        let granter_addr = daemon.sender_addr();
 
         let second_daemon: Daemon = daemon
             .rebuild()
             .build_sender(
                 CosmosOptions::default()
                     .mnemonic(SECOND_MNEMONIC)
-                    .authz_granter(&sender),
+                    .authz_granter(&granter_addr),
             )
             .unwrap();
+        // Actual sender is expected to be authz granter
+        assert_eq!(second_daemon.sender_addr(), daemon.sender_addr());
+        // We still can get signer AccountId, if needed
+        let grantee_account_id = second_daemon.sender().signer_account_id();
+        let granter_account_id = second_daemon.sender().account_id();
+        assert_ne!(grantee_account_id, daemon.sender().account_id());
+
+        let grantee = Addr::unchecked(grantee_account_id.to_string());
+        let granter = Addr::unchecked(granter_account_id.to_string());
 
         let runtime = daemon.rt_handle.clone();
-
-        let grantee = second_daemon.sender_addr();
 
         let current_timestamp = daemon.block_info()?.time;
 
@@ -72,7 +83,7 @@ mod tests {
             vec![Any {
                 type_url: "/cosmos.authz.v1beta1.MsgGrant".to_string(),
                 value: MsgGrant {
-                    granter: sender.to_string(),
+                    granter: granter.to_string(),
                     grantee: grantee.to_string(),
                     grant: Some(grant.clone()),
                 }
@@ -83,7 +94,7 @@ mod tests {
 
         // Check Queries of the authz
         let grant_authorization = GrantAuthorization {
-            granter: sender.to_string(),
+            granter: granter.to_string(),
             grantee: grantee.to_string(),
             authorization: Some(authorization.clone()),
             expiration: Some(expiration),
@@ -93,7 +104,7 @@ mod tests {
         let authz_querier: Authz = daemon.querier();
         let grants: QueryGrantsResponse = runtime.block_on(async {
             authz_querier
-                ._grants(&sender, &grantee, MsgSend::type_url(), None)
+                ._grants(&granter, &grantee, MsgSend::type_url(), None)
                 .await
         })?;
         assert_eq!(grants.grants, vec![grant]);
@@ -105,14 +116,14 @@ mod tests {
 
         // Granter grants
         let granter_grants: QueryGranterGrantsResponse =
-            runtime.block_on(async { authz_querier._granter_grants(&sender, None).await })?;
+            runtime.block_on(async { authz_querier._granter_grants(&granter, None).await })?;
         assert_eq!(granter_grants.grants, vec![grant_authorization]);
 
         // No grant gives out an error
         runtime
             .block_on(async {
                 authz_querier
-                    ._grants(&grantee, &sender, MsgSend::type_url(), None)
+                    ._grants(&grantee, &granter, MsgSend::type_url(), None)
                     .await
             })
             .unwrap_err();

--- a/cw-orch-daemon/tests/daemon_state.rs
+++ b/cw-orch-daemon/tests/daemon_state.rs
@@ -4,7 +4,7 @@ use cw_orch_core::environment::ChainState;
 use cw_orch_daemon::{
     env::STATE_FILE_ENV_NAME,
     json_lock::JsonLockedState,
-    networks::{JUNO_1, NEUTRON_1},
+    networks::{JUNO_1, XION_MAINNET_1},
     Daemon, DaemonBuilder, DaemonError, DaemonStateFile,
 };
 
@@ -208,7 +208,7 @@ fn reuse_same_state_multichain() {
         .build()
         .unwrap();
 
-    let daemon_res = DaemonBuilder::new(NEUTRON_1)
+    let daemon_res = DaemonBuilder::new(XION_MAINNET_1)
         .state(daemon.state())
         .mnemonic(DUMMY_MNEMONIC)
         .build();


### PR DESCRIPTION
Currently `account_id()` for Wallet ignores authz_granter, always returning account_id of the signer. It creates issues when user want to send a message from authz_granter, but sender gets autofilled as signer.
This PR fixes it by using authz_granter for account_id() and adding `signer_account_id()` in case user will need an actual address of the signer(rarely the case)
Fixes #541
### Checklist

- [ ] Changelog updated.
- [ ] Docs updated.
